### PR TITLE
feat(brs): Add initial version of roca.brs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "main": "src/index.js",
   "files": [
-    "./bin/"
+    "./bin/",
+    "resources"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/resources/roca.brs
+++ b/resources/roca.brs
@@ -1,3 +1,7 @@
+' Creates a suite of test cases with a given description.
+' @param description a string describing the suite of tests contained within.
+' @param context the context from the parent `describe`, used to create sub-suites.  Use `invalid` for the top-level suite.
+' @param func the function to execute as part of this suite.
 sub describe(description as string, context as object, func as object)
     if context = invalid then
         context = createContext()
@@ -22,10 +26,17 @@ sub describe(description as string, context as object, func as object)
     end if
 end sub
 
+' Creates a test case with a given description.
+' @param description a string describing this test case
+' @param context the context from the parent 'describe', used to track test pass and fail states
+' @param func the function to execute as part of this test case
 sub it(description as string, context as object, func as object)
     context.__registerCase(description, context, func)
 end sub
 
+' Creates a new test or suite context, which encapsulates the test or suite's internal state and provides the test API
+' to consumers.
+' @returns a new test case or suite context
 sub createContext()
     return {
         __state: {
@@ -41,7 +52,11 @@ sub createContext()
     }
 end sub
 
-sub __context_registerCase(description as string, context, func as object)
+' Registers a test case with the provided description and function in the given context.
+' @param description a string describing the test case
+' @param context the context from the parent 'describe', used to track test pass and fail states
+' @param func the function to execute as part of the test case
+sub __context_registerCase(description as string, context as object, func as object)
     m.__state.cases.push({
         description: description,
         func: func,
@@ -49,6 +64,10 @@ sub __context_registerCase(description as string, context, func as object)
     })
 end sub
 
+' Registers a test case with the provided description and function in the given context.
+' @param description a string describing the suite of tests contained within.
+' @param context the context from the parent `describe`, used to create sub-suites.  Use `invalid` for the top-level suite.
+' @param func the function to execute as part of this suite.
 sub __context_registerSuite(description as string, context as object, func as object)
     m.__state.suites.push({
         description: description,
@@ -57,10 +76,12 @@ sub __context_registerSuite(description as string, context as object, func as ob
     })
 end sub
 
+' Forces a test case into a "success" state.
 sub __context_pass()
     m.__state.success = true
 end sub
 
+' Forces a test case into a "failure" state.
 sub __context_fail()
     m.__state.success = false
 end sub

--- a/resources/roca.brs
+++ b/resources/roca.brs
@@ -30,8 +30,17 @@ sub describe(description as string, parentContext as object, func as object)
         ' then execute each test and report its results
         index = 1
         for each case in allTests
-            case.func(case.ctx)
+            ' package the test case up with some test utilities accessible via `m.`
+            withUtils = {
+                pass: __util_pass,
+                fail: __util_fail,
+                __ctx: case.ctx,
+                __func: case.func
+            }
+            ' then call it
+            withUtils.__func()
 
+            ' and report the results
             description = buildDescription(case)
             if case.ctx.__state.success then
                 print "ok " index " - " description
@@ -92,10 +101,9 @@ end function
 
 ' Creates a test case with a given description.
 ' @param description a string describing this test case
-' @param context the context from the parent 'describe', used to track test pass and fail states
 ' @param func the function to execute as part of this test case
-sub it(description as string, context as object, func as object)
-    context.__registerCase(description, context, func)
+sub it(description as string, func as object)
+    m.ctx.__registerCase(description, m.ctx, func)
 end sub
 
 ' Creates a new test or suite context, which encapsulates the test or suite's internal state and provides the test API
@@ -112,8 +120,6 @@ sub createContext()
         },
         __registerSuite: __context_registerSuite,
         __registerCase: __context_registerCase
-        pass: __context_pass,
-        fail: __context_fail
     }
 end sub
 
@@ -141,11 +147,11 @@ sub __context_registerSuite(context as object, func as object)
 end sub
 
 ' Forces a test case into a "success" state.
-sub __context_pass()
-    m.__state.success = true
+sub __util_pass()
+    m.__ctx.__state.success = true
 end sub
 
 ' Forces a test case into a "failure" state.
-sub __context_fail()
-    m.__state.success = false
+sub __util_fail()
+    m.__ctx.__state.success = false
 end sub

--- a/resources/roca.brs
+++ b/resources/roca.brs
@@ -1,0 +1,66 @@
+sub describe(description as string, context as object, func as object)
+    if context = invalid then
+        context = createContext()
+    end if
+
+    context.__registerSuite(description, context, func)
+
+    func(context)
+
+    if context.__state.parentCtx = invalid then
+        ' calls func, checks the result, and prints "ok" or "not ok" followed by the description variable
+        for each case in context.__state.cases
+            ' TODO: recursively execute tests
+            case.func(case.ctx)
+
+            if case.ctx.__state.success then
+                print "ok - " case.description
+            else
+                print "not ok - " case.description
+            end if
+        end for
+    end if
+end sub
+
+sub it(description as string, context as object, func as object)
+    context.__registerCase(description, context, func)
+end sub
+
+sub createContext()
+    return {
+        __state: {
+            parentCtx: invalid,
+            success: true,
+            cases: [],
+            suites: []
+        },
+        __registerSuite: __context_registerSuite,
+        __registerCase: __context_registerCase
+        pass: __context_pass,
+        fail: __context_fail
+    }
+end sub
+
+sub __context_registerCase(description as string, context, func as object)
+    m.__state.cases.push({
+        description: description,
+        func: func,
+        ctx: context
+    })
+end sub
+
+sub __context_registerSuite(description as string, context as object, func as object)
+    m.__state.suites.push({
+        description: description,
+        func: func,
+        ctx: context
+    })
+end sub
+
+sub __context_pass()
+    m.__state.success = true
+end sub
+
+sub __context_fail()
+    m.__state.success = false
+end sub

--- a/resources/roca.brs
+++ b/resources/roca.brs
@@ -14,6 +14,7 @@ sub describe(description as string, func as object)
     withM = {
         __ctx: context
         __func: func
+        __log: __util_log
     }
     withM.__func()
 
@@ -38,6 +39,7 @@ sub describe(description as string, func as object)
             withM = {
                 pass: __util_pass,
                 fail: __util_fail,
+                log: __util_log,
                 __ctx: case.ctx,
                 __func: case.func
             }
@@ -158,4 +160,10 @@ end sub
 ' Forces a test case into a "failure" state.
 sub __util_fail()
     m.__ctx.__state.success = false
+end sub
+
+' Prints messages to stdout in a TAP-compliant format
+' @param msg the message to print as a TAP diagnostic
+sub __util_log(msg as string)
+    print "# " msg
 end sub

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const brs = require('brs');
 const glob = require('glob');
+const path = require('path');
 
 function findBrsFiles(testFile, cb) {
     glob("source/**/*.brs", (err, files) => {
@@ -11,8 +12,10 @@ function findBrsFiles(testFile, cb) {
 }
 
 async function runTest(files) {
+    let rocaBrs = path.join(__dirname, "..", "resources", "roca.brs");
+
     try {
-        const result = await brs.execute(files);
+        const result = await brs.execute([ rocaBrs, ...files ]);
     } catch(e) {
         console.error("Interpreter found an error: ", e);
         process.exit(11);


### PR DESCRIPTION
Our testing API will be shipped with this node module via the `files` array in package.json, making it accessible to anyone who runs `roca`.  By producing TAP-compliant output, we can let consumers choose their preferred reporter.  I've tested this output with:

* https://github.com/substack/tap-colorize
* https://github.com/calvinmetcalf/tap-nyan
* https://github.com/scottcorgan/tap-spec
* https://github.com/substack/faucet

Example test file:

```brightscript
function addOne(i)
    return i + 1
end function

sub main()
    describe("addOne", sub()
        describe("nested", sub()
            describe("L3", sub()
                it("works", sub()
                    m.pass()
                end sub)
            end sub)

            it("adds one to positive integers", sub()
                if addOne(1) = 2 then
                    m.pass()
                else
                    m.fail()
                end if
            end sub)

            it("adds one to negative integers", sub()
                if addOne(-1) = 0 then
                    m.pass()
                else
                    m.fail()
                end if
            end sub)

            it("adds one to strings", sub()
                if addOne(5) = "six" then
                    m.pass()
                else
                    m.fail()
                end if
            end sub)
        end sub)

        it("is only nested one level", sub()
            m.fail()
        end sub)
    end sub)
end sub
```

And output (with no formatters)

```
$ roca file foo.test.brs
TAP version 13
1..5
ok 1 - addOne nested L3 works
ok 2 - addOne nested adds one to positive integers
ok 3 - addOne nested adds one to negative integers
not ok 4 - addOne nested adds one to strings
not ok 5 - addOne is only nested one level
```