### PR TITLE
fix(build): Ensure cli/bin.js gets packed for publication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/roca",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hulu/roca",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A command-line tool for running brightscript tests",
   "bin": {
     "roca": "./bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "main": "src/index.js",
   "files": [
-    "./bin/",
-    "resources"
+    "bin/",
+    "resources/"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
My bad!  `@hulu/roca` isn't currently `npm install`-able without the `cli.js` file.