### PR TITLE
feat(report): Include tap mocha reporter by default

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,16 +7,10 @@ const argv = require('yargs')
         "Options:": "Other Options"
     })
     .command(
-        "file <file>",
-        "Run tests on given file", 
-        (yargs) => {
-            yargs.positional("file", {
-                type: "string",
-                describe: "The test file to execute"
-            })
-        },
+        ["$0", "run"],
+        "Discovers and executes all .test.brs tests in the current directory", 
         (argv) => {
-            testRunner(argv.file, argv.s);
+            testRunner(argv.s);
         }
     )
     .describe('s', 'Path to brs files (if different from source/)')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,10 +7,41 @@ const argv = require('yargs')
         "Options:": "Other Options"
     })
     .command(
-        ["$0", "run"],
+        ["$0", "run "],
         "Discovers and executes all .test.brs tests in the current directory", 
-        (argv) => {
-            testRunner(argv.s);
+        (yargs) => {
+            yargs.option("reporter", {
+                // use capital-R for reporter selection to match mocha
+                alias: "R",
+                type: "string",
+                describe: "The mocha reporter to use, via tap-mocha-reporter",
+                default: "spec",
+                choices: [
+                    "classic",
+                    "doc",
+                    "dot",
+                    "dump",
+                    "json",
+                    "jsonstream",
+                    "landing",
+                    "list",
+                    "markdown",
+                    "min",
+                    "nyan",
+                    "progress",
+                    "silent",
+                    "spec",
+                    "tap",
+                    "xunit"
+                ],
+            })
+
+        },
+        async (argv) => {
+            await testRunner({
+                sourceDir: argv.s,
+                reporter: argv.reporter
+            });
         }
     )
     .describe('s', 'Path to brs files (if different from source/)')

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+      "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -218,6 +226,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
@@ -240,7 +253,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.com/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
@@ -282,6 +295,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -297,11 +315,21 @@
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "resolved": "http://registry.npmjs.com/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "~1.0.1"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
     },
     "execa": {
       "version": "1.0.0",
@@ -513,7 +541,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.com/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
@@ -550,7 +578,7 @@
     },
     "long": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.com/long/-/long-3.2.0.tgz",
       "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "luxon": {
@@ -591,7 +619,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "resolved": "http://registry.npmjs.com/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
         "errno": "^0.1.3",
@@ -609,6 +637,14 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "minipass": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.0.1.tgz",
+      "integrity": "sha512-2y5okJ4uBsjoD2vAbLKL9EUQPPkC0YMIp+2mZOXG3nBba++pdfJWRxx2Ewirc0pwAJYu4XtWg2EkVo1nRXuO/w==",
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "mixin-deep": {
@@ -768,7 +804,7 @@
     },
     "p-limit": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.com/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
         "p-try": "^1.0.0"
@@ -799,12 +835,12 @@
     },
     "p-reflect": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.com/p-reflect/-/p-reflect-1.0.0.tgz",
       "integrity": "sha1-9Poe4btUbY6z7AMhFI3+CnkTe7g="
     },
     "p-settle": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.com/p-settle/-/p-settle-2.1.0.tgz",
       "integrity": "sha512-NHFIUYc+fQTFRrzzAugq0l1drwi57PB522smetcY8C/EoTYs6cU/fC6TJj0N3rq5NhhJJbhf0VGWziL3jZDnjA==",
       "requires": {
         "p-limit": "^1.2.0",
@@ -813,7 +849,7 @@
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.com/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "pascalcase": {
@@ -843,7 +879,7 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.com/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pump": {
@@ -855,9 +891,14 @@
         "once": "^1.3.1"
       }
     },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.com/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -868,6 +909,11 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -900,7 +946,7 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "http://registry.npmjs.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
@@ -1166,7 +1212,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.com/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1184,6 +1230,40 @@
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.com/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "tap-mocha-reporter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.0.tgz",
+      "integrity": "sha512-8HlAtdmYGlDZuW83QbF/dc46L7cN+AGhLZcanX3I9ILvxUAl+G2/mtucNPSXecTlG/4iP1hv6oMo0tMhkn3Tsw==",
+      "requires": {
+        "color-support": "^1.1.0",
+        "debug": "^2.1.3",
+        "diff": "^1.3.2",
+        "escape-string-regexp": "^1.0.3",
+        "glob": "^7.0.5",
+        "readable-stream": "^2.1.5",
+        "tap-parser": "^10.0.0",
+        "tap-yaml": "^1.0.0",
+        "unicode-length": "^1.0.0"
+      }
+    },
+    "tap-parser": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.0.0.tgz",
+      "integrity": "sha512-kzeUPvVoSyovAlYvN8m8eajjh1LAJpGn8C3hVIbq7TDW6FDzuH09egdJZMczG4bDdc7+uQSqOlin+XKRLtHbeA==",
+      "requires": {
+        "events-to-array": "^1.0.1",
+        "minipass": "^3.0.0",
+        "tap-yaml": "^1.0.0"
+      }
+    },
+    "tap-yaml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
+      "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
+      "requires": {
+        "yaml": "^1.5.0"
+      }
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -1212,6 +1292,30 @@
         "extend-shallow": "^3.0.2",
         "regex-not": "^1.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "unicode-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
+      "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+      "requires": {
+        "punycode": "^1.3.2",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "union-value": {
@@ -1280,7 +1384,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "which": {
@@ -1315,6 +1419,19 @@
       "version": "4.0.0",
       "resolved": "http://registry.npmjs.com/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.1.tgz",
+      "integrity": "sha512-sR0mJ2C3LVBgMST+0zrrrsKSijbw64bfHmTt4nEXLZTZFyIAuUVARqA/LO5kaZav2OVQMaZ+5WRrZv7QjxG3uQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5"
+      }
     },
     "yargs": {
       "version": "13.2.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "brs": "^0.15.0",
     "glob": "^7.1.4",
+    "tap-mocha-reporter": "^5.0.0",
     "yargs": "^13.2.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,11 @@ const brs = require('brs');
 const glob = require('glob');
 const path = require('path');
 
-function findBrsFiles(testFile, sourceDir, cb) {
+function findBrsFiles(sourceDir, cb) {
     let searchDir = sourceDir || 'source';
     const pattern = path.join(searchDir, '**', '*.brs');
     glob(pattern, (err, files) => {
         if (!err) {
-            files.push(testFile);
             cb(files);
         }
     });
@@ -24,11 +23,10 @@ async function runTest(files) {
         const result = await brs.execute([ ...rocaFiles, ...files ]);
     } catch(e) {
         console.error("Interpreter found an error: ", e);
-        process.exit(11);
+        process.exitCode = 1;
     }
-    process.exit(0);
 }
 
-module.exports = function(testFile, sourceDir) {
-    findBrsFiles(testFile, sourceDir, runTest);
+module.exports = function(sourceDir) {
+    findBrsFiles(sourceDir, runTest);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,16 @@
 const brs = require('brs');
 const glob = require('glob');
 const path = require('path');
+const util = require('util');
+const TapMochaReporter = require('tap-mocha-reporter');
 
-function findBrsFiles(sourceDir, cb) {
+async function findBrsFiles(sourceDir) {
     let searchDir = sourceDir || 'source';
     const pattern = path.join(searchDir, '**', '*.brs');
-    glob(pattern, (err, files) => {
-        if (!err) {
-            cb(files);
-        }
-    });
+    return util.promisify(glob)(pattern);
 }
 
-async function runTest(files) {
+async function runTest(files, reporter) {
     let rocaFiles = [
         "tap.brs",
         "roca_lib.brs",
@@ -20,13 +18,20 @@ async function runTest(files) {
     ].map(basename => path.join(__dirname, "..", "resources", basename));
 
     try {
-        const result = await brs.execute([ ...rocaFiles, ...files ]);
+        let reporterStream = new TapMochaReporter(reporter);
+        await brs.execute([ ...rocaFiles, ...files], {
+            stdout: reporterStream,
+            stderr: process.stderr
+        });
+        reporterStream.end();
     } catch(e) {
         console.error("Interpreter found an error: ", e);
         process.exitCode = 1;
     }
 }
 
-module.exports = function(sourceDir) {
-    findBrsFiles(sourceDir, runTest);
+module.exports = async function(options) {
+    let { sourceDir, reporter } = options;
+    let files = await findBrsFiles(sourceDir);
+    await runTest(files, reporter);
 }


### PR DESCRIPTION
Rather than hand-writing our own reporters, we can pipe `brs`'s `stdout` directly through `tap-mocha-reporter` and leverage all of the reporters that it supports.  That's more than enough to get us started, and allows `roca` users to write their own TAP reporters as desired!