### PR TITLE
fix: Tap reporter uses correct index case

### DIFF
--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -179,7 +179,7 @@ sub __suite_exec(args as object)
     end for
     tap.exitSubTest()
 
-    index = args.index
+    index = 0
     for each case in m.__state.cases
         tap.indent()
         if (args.focusedCasesDetected and case.mode = "focus") or not args.focusedCasesDetected then

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -179,7 +179,7 @@ sub __suite_exec(args as object)
     end for
     tap.exitSubTest()
 
-    index = 0
+    index = subTestIndex
     for each case in m.__state.cases
         tap.indent()
         if (args.focusedCasesDetected and case.mode = "focus") or not args.focusedCasesDetected then


### PR DESCRIPTION
The case index in a suite should be reset after executing the whole suite.