### PR TITLE
feat(api): Basic assertion library

### DIFF
--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -1,0 +1,52 @@
+function Assert(passFunc, failFunc, state) as object
+    return {
+        __pass: passFunc,
+        __fail: failFunc,
+        __state: state
+        equal: __equal,
+        notEqual: __notEqual,
+        isTrue: __isTrue,
+        isFalse: __isFalse,
+        isInvalid: __isInvalid
+    }
+end function
+
+sub __equal(actual, expected)
+    if actual = expected then
+        m.__pass()
+    else
+        m.__fail()
+    end if
+end sub
+
+sub __notEqual(actual, expected)
+    if actual <> expected then
+        m.__pass()
+    else
+        m.__fail()
+    end if
+end sub
+
+sub __isTrue(actual)
+    if actual = true then
+        m.__pass()
+    else
+        m.__fail()
+    end if
+end sub
+
+sub __isFalse(actual)
+    if actual = false then
+        m.__pass()
+    else
+        m.__fail()
+    end if
+end sub
+
+sub __isInvalid(actual)
+    if actual = invalid then
+        m.__pass()
+    else
+        m.__fail()
+    end if
+end sub

--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -7,46 +7,56 @@ function Assert(passFunc, failFunc, state) as object
         notEqual: __notEqual,
         isTrue: __isTrue,
         isFalse: __isFalse,
-        isInvalid: __isInvalid
+        isInvalid: __isInvalid,
+        formatError: __formatError
     }
 end function
 
-sub __equal(actual, expected)
+sub __equal(actual, expected, error)
     if actual = expected then
         m.__pass()
     else
-        m.__fail()
+        m.__fail(m.formatError(error))
     end if
 end sub
 
-sub __notEqual(actual, expected)
+sub __notEqual(actual, expected, error)
     if actual <> expected then
         m.__pass()
     else
-        m.__fail()
+        m.__fail(m.formatError(error))
     end if
 end sub
 
-sub __isTrue(actual)
+sub __isTrue(actual, error)
     if actual = true then
         m.__pass()
     else
-        m.__fail()
+        m.__fail(m.formatError(error))
     end if
 end sub
 
-sub __isFalse(actual)
+sub __isFalse(actual, error)
     if actual = false then
         m.__pass()
     else
-        m.__fail()
+        m.__fail(m.formatError(error))
     end if
 end sub
 
-sub __isInvalid(actual)
+sub __isInvalid(actual, error)
     if actual = invalid then
         m.__pass()
     else
-        m.__fail()
+        m.__fail(m.formatError(error))
     end if
 end sub
+
+function __formatError(errMessage)
+    return {
+        error: {
+            message: errMessage
+        },
+        stack: {}
+    }
+end function

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -111,6 +111,7 @@ function __case_execute()
         __suite: m.suite,
         __func: m.func,
         __state: m.__state
+        assert: assert(__util_pass, __util_fail, m.__state)
     }
     withM.__func()
 end function

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -94,6 +94,7 @@ sub __suite_registerCase(mode as string, description as string, suite as object,
         mode: mode,
         __state: {
             success: invalid
+            metadata: invalid
         },
         description: description,
         func: func,
@@ -126,7 +127,7 @@ function __case_report(index as integer, tap as object) as string
         tap.pass(index, m.description)
         return "passed"
     else if m.__state.success = false then
-        tap.fail(index, m.description)
+        tap.fail(index, m.description, m.__state.metadata)
         return "failed"
     end if
 end function
@@ -218,8 +219,9 @@ sub __util_pass()
 end sub
 
 ' Forces a test case into a "failure" state.
-sub __util_fail()
+sub __util_fail(metadata = invalid)
     m.__state.success = false
+    m.__state.metadata = metadata
 end sub
 
 ' Prints messages to stdout in a TAP-compliant format

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ async function runTest(files, reporter) {
     let rocaFiles = [
         "tap.brs",
         "roca_lib.brs",
-        "roca_main.brs"
+        "roca_main.brs",
+        "assert_lib.brs"
     ].map(basename => path.join(__dirname, "..", "resources", basename));
 
     try {


### PR DESCRIPTION
I've started a very basic assertion library with just a few methods. The idea is to make developers' lives simpler when writing brightscript tests. 🎅 
Currently just one assertion per case is supported and there is no support for messages on failed assertions, will work on that later. 

Examples of usage:
```
describe("testing assertion", sub()
    m.it("tests equality", sub()
        m.assert.equal(1, 2)
    end sub)

    m.it("test isTrue", sub()
        m.assert.isTrue(true)
    end sub)

    m.it("tests invalid", sub()
        m.assert.isInvalid(invalid)
    end sub)
end sub)
```
