### PR TITLE
chore(deps): Update brs from 0.17.0 to 0.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,9 +120,9 @@
       }
     },
     "brs": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/brs/-/brs-0.17.0.tgz",
-      "integrity": "sha512-nSxJbdcJrbJq7aJ+8Mhzv85OU5WcUij8M27EEk8sUmOzuO/34UlMYVoXB6/T5ecffUtTIXWOiBqaRILFoWCiuA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/brs/-/brs-0.17.1.tgz",
+      "integrity": "sha512-oWlL9hFfVrfYxMEVg+vd+LaVcSl3isxt/QXz+fJ2u0Ub15dlW/HmTGZSJvALpousY1kqQJscDk62vbNANgPGhg==",
       "requires": {
         "commander": "^2.12.2",
         "fast-glob": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/hulu/roca#readme",
   "dependencies": {
-    "brs": "^0.17.0",
+    "brs": "^0.17.1",
     "glob": "^7.1.4",
     "tap-mocha-reporter": "^5.0.0",
     "yargs": "^13.2.4"


### PR DESCRIPTION
0.17.1 prevents an infinite loop when processing custom components that extend not-yet-implemented components.

More details at https://github.com/sjbarag/brs/releases/tag/v0.17.1