### PR TITLE
feat(discovery): Find tests recursively from package root

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Roca only supports a main channel entry point of `runUserInterface`, which helpf
 Luckily `runUserInterface` is supported for all the same use-cases as `main`: https://developer.roku.com/docs/developer-program/getting-started/architecture/dev-environment.md#sub-runuserinterface
 
 ### Adding a Test
-Just like [Mocha](https://mochajs.org/) tests are written in JavaScript, roca tests are written in BrightScript.  Roca will find and execute all files in the `./tests/` directory that match `*.test.brs`.  The smallest possible unit test must meet the following requirements:
+Just like [Mocha](https://mochajs.org/) tests are written in JavaScript, roca tests are written in BrightScript.  Roca will recursively find and execute all files that match `*.test.brs` in any of the following directories: `source/`, `components/`, `tests/`, and `test/`. The smallest possible unit test must meet the following requirements:
 
 1. A function called `main` that accepts one argument of type `object` and returns a value of type `object`
 2. That `main` function initializes a Roca instance by passing the arguments from (1) into `roca()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,9 +283,9 @@
       }
     },
     "brs": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/brs/-/brs-0.25.1.tgz",
-      "integrity": "sha512-26lbQxMdbl7afmAJLxOxoEeCWsPR3VcxwX6twW5ZMUrIBYgQvlY95zCjVzegBH3deC27OCkl5E7ezEe2hC3jdQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/brs/-/brs-0.27.0.tgz",
+      "integrity": "sha512-PTnKd4e/fLFhT7HDevcIzWV7tvHusmIcvusxLb1aE0CjUJbAmp5p5bz7zPpzS+yjMzl0QV18J1cWS5GRZRKDvQ==",
       "dev": true,
       "requires": {
         "commander": "^2.12.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
-    "brs": "^0.25.0",
+    "brs": "^0.27.0",
     "doctoc": "^1.4.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11"


### PR DESCRIPTION
Previously we only searched in `tests/*.test.brs` files because `MatchFiles` doesn't work recursively.  A combination of `ListDir` and `MatchFiles` lets us manually do that search recursively -- luckily it's not terribly slow as far as I can tell!

fixes #18
closes #10 (no need for configuration if we search everything)