### PR TITLE
Implement deepEquals test assertion utility for unit testing

### DIFF
--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -60,3 +60,8 @@ function __formatError(errMessage)
         stack: {}
     }
 end function
+
+function __deepEquals(actual, expected)
+    print "DEEP EQUALS IMPLEMENTATION GOES HERE"
+
+end function

--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -70,7 +70,6 @@ sub __deepEquals(actual, expected, error)
     end if
 end sub
 
-
 'utility function to compare two objects/associative arrays with nested data structures
 function deepEquals(left as object, right as object) as boolean
     ' because Brightsript does not support closures and we are doing recursion,

--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -8,7 +8,8 @@ function Assert(passFunc, failFunc, state) as object
         isTrue: __isTrue,
         isFalse: __isFalse,
         isInvalid: __isInvalid,
-        formatError: __formatError
+        formatError: __formatError,
+        deepEquals: __deepEquals
     }
 end function
 
@@ -61,7 +62,81 @@ function __formatError(errMessage)
     }
 end function
 
-function __deepEquals(actual, expected)
-    print "DEEP EQUALS IMPLEMENTATION GOES HERE"
+sub __deepEquals(actual, expected, error)
+    if deepEquals(actual, expected) = true then
+        m.__pass()
+    else
+        m.__fail(m.formatError(error))
+    end if
+end sub
 
+
+'utility function to compare two objects/associative arrays with nested data structures
+function deepEquals(left as object, right as object) as boolean
+    ' because Brightsript does not support closures and we are doing recursion,
+    'we want to hold the function parameters in top-level state variables during each execution
+    updatedLeftState = invalid
+    updatedRightState = invalid
+    isEqual = true
+
+    if type(left) <> type(right) then return false
+
+    if isArray(left) and isArray(right) then
+        if left.count() <> right.count() then return false
+
+        updatedLeftState = left
+        updatedRightState = right
+
+        index = 0
+        for each updatedLeft in updatedLeftState
+            updatedRight = updatedRightState[index]
+
+            isEqual = deepEquals(updatedLeft, updatedRight)
+
+            index++
+        end for
+    end if
+
+    if isAssociativeArray(left) and isAssociativeArray(right) then
+        for each key in left.keys()
+            if not right.doesExist(key) then return false
+
+            if isArray(left[key]) and isArray(right[key]) and left[key].count() <> right[key].count() then
+                return false
+            end if
+
+            if isArray(left[key]) and isArray(right[key])then
+                updatedLeftState = left[key]
+                updatedRightState = right[key]
+
+                isEqual = deepEquals(updatedLeftState, updatedRightState)
+
+                if isEqual = false then exit for
+            end if
+
+            if isAssociativeArray(left[key]) and isAssociativeArray(right[key]) then
+                updatedLeftState = left[key]
+                updatedRightState = right[key]
+
+                isEqual = deepEquals(updatedLeftState, updatedRightState)
+
+                if isEqual = false then exit for
+            end if
+
+            ' we are at the point which the left and right data types coulbe primitive values (strings, integers, etc)
+            if not (isAssociativeArray(left[key]) and isAssociativeArray(right[key])) and not (isArray(left[key]) and isArray(right[key])) then
+                if left[key] <> right[key] then return false
+            end if
+        end for
+    end if
+
+    return isEqual
+end function
+
+function isArray(obj as dynamic) as boolean
+    return isValid(obj) and getInterface(obj, "ifArray") <> invalid
+end function
+
+function isAssociativeArray(obj as dynamic) as boolean
+    return isValid(obj) and getInterface(obj, "ifAssociativeArray") <> invalid
 end function


### PR DESCRIPTION
This includes a 'deepEquals' implementation for making unit test assertions. Sometimes we want to compare the equality between associative arrays that have a deep nested structure that a simple equality check won't do. This implementation performs a recursive check against data types, compares them, and returns a boolean value if the two comparative data types are equal or not.