### PR TITLE
feat(discovery,api): Find brs files in components folder. Added exclusions

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,7 +45,7 @@ const argv = require('yargs')
         }
     )
     .describe('e', 'List of directories to exclude (i.e. foo,bar)')
-    .alias("e", "exclude")
+    .alias("e", "excludes")
     .help("h")
     .alias("h", "help")
     .argv;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ const argv = require('yargs')
     })
     .command(
         ["$0", "run "],
-        "Discovers and executes all .test.brs tests in the current directory", 
+        "Discovers and executes all .test.brs tests in the current directory",
         (yargs) => {
             yargs.option("reporter", {
                 // use capital-R for reporter selection to match mocha
@@ -39,13 +39,13 @@ const argv = require('yargs')
         },
         async (argv) => {
             await testRunner({
-                sourceDir: argv.s,
+                exclusions: argv.e,
                 reporter: argv.reporter
             });
         }
     )
-    .describe('s', 'Path to brs files (if different from source/)')
-    .alias("s", "source")
+    .describe('e', 'List of directories to exclude (i.e. foo,bar)')
+    .alias("e", "exclude")
     .help("h")
     .alias("h", "help")
     .argv;

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const TapMochaReporter = require('tap-mocha-reporter');
 
 async function findBrsFiles(exclusions) {
     const defaultDirs = ['source', 'components'];
-    let exclusionList = [];
+    let exclusionList = ['test', 'tests', 'node_modules'];
 
     if (exclusions) {
         exclusionList = exclusions.trim().split(',');

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,20 @@ const path = require('path');
 const util = require('util');
 const TapMochaReporter = require('tap-mocha-reporter');
 
-async function findBrsFiles(sourceDir) {
-    let searchDir = sourceDir || 'source';
-    const pattern = path.join(searchDir, '**', '*.brs');
+async function findBrsFiles(exclusions) {
+    const defaultDirs = ['source', 'components'];
+    let exclusionList = [];
+
+    if (exclusions) {
+        exclusionList = exclusions.trim().split(',');
+    }
+
+    let inclusionList = defaultDirs
+        .filter( dir => !exclusionList.includes(dir))
+        .map( dir => path.join(dir, '**', '*.brs'));
+
+    let pattern = inclusionList.length > 1 ? `{${inclusionList.join(',')}}` : inclusionList[0];
+
     return util.promisify(glob)(pattern);
 }
 
@@ -32,7 +43,7 @@ async function runTest(files, reporter) {
 }
 
 module.exports = async function(options) {
-    let { sourceDir, reporter } = options;
-    let files = await findBrsFiles(sourceDir);
+    let { exclusions, reporter } = options;
+    let files = await findBrsFiles(exclusions);
     await runTest(files, reporter);
 }


### PR DESCRIPTION
- Added support to find `.brs` that are located in the components folder (and subfolders) to allow components testing.
- Changed the accepted `source` argument to an `excludes` option that accepts a list of folder names to be excluded. I find this option more helpful because a real Roku device would look for those directories and fail if not found.