### PR TITLE
Implement fdescribe and xdescribe

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -163,10 +163,10 @@ Example:
 ```brightscript
 m.xdescribe("an skipped test suite", sub()
     m.it("a test case", sub()
-        ' this test won't run, because another suite is focused
+        ' this test will be skipped, because it's inside of a skipped suite
     end sub)
 
-    ' This sub-suite will be skipped, because it's inside of a focused suite
+    ' This sub-suite will be skipped, because it's inside of a skipped suite
     m.describe("a sub-suite", sub() 
         m.it("a test case inside of the sub-suite", sub()
             ' this test will be skipped, because it has skipped ancestors

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,58 @@ m.it("a test case", sub()
 end sub)
 ```
 
+#### `m.fdescribe(description as string, func as object)`
+Creates a focused test suite &mdash; a test suite that causes all non-focused tests *in all files* to be ignored.  Useful when debugging specific sets of unit tests.
+
+Parameters:
+* `description as string` - a string describing the test case executed by `func`
+* `func as object` - the function to execute as part of this test case
+
+Example:
+```brightscript
+m.describe("an unfocused test suite", sub()
+    m.it("a test case", sub()
+        ' this test won't run, because another suite is focused
+    end sub)
+end sub)
+
+m.fdescribe("a focused test suite", sub() 
+    m.it("a test case inside of a focused suite", sub()
+        ' this test *will* be executed, because it's inside a focused suite
+    end sub)
+
+    ' This sub-suite will run, because it's inside of a focused suite
+    m.describe("a sub-suite", sub() 
+        m.it("a test case inside of the sub-suite", sub()
+            ' this test *will* be executed, because it has focused ancestors
+        end sub)
+    end sub)
+end sub)
+```
+
+#### `m.xdescribe(description as string, func as object)`
+Creates a skipped unit test suite.  Any tests and sub-suites inside it will never execute.
+
+Parameters:
+* `description as string` - a string describing the test case executed by `func`
+* `func as object` - the function to execute as part of this test case
+
+Example:
+```brightscript
+m.xdescribe("an skipped test suite", sub()
+    m.it("a test case", sub()
+        ' this test won't run, because another suite is focused
+    end sub)
+
+    ' This sub-suite will be skipped, because it's inside of a focused suite
+    m.describe("a sub-suite", sub() 
+        m.it("a test case inside of the sub-suite", sub()
+            ' this test will be skipped, because it has skipped ancestors
+        end sub)
+    end sub)
+end sub)
+```
+
 #### `m.fit(description as string, func as object)`
 Creates a focused test case &mdash; a test case that causes all non-focused tests *in all files* to be skipped.  Useful when debugging specific unit tests.
 

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -8,23 +8,48 @@ function roca(args = {} as object)
     return {
         log: __util_log,
         args: args,
+        __createDescribeBlock: __roca_createDescribeBlock,
         describe: __roca_describe,
+        fdescribe: __roca_fdescribe,
+        xdescribe: __roca_xdescribe,
         it: __it,
         fit: __fit,
         xit: __xit
     }
 end function
 
-' Creates a suite of test cases with a given description.
 ' @param {string} description - a string describing the suite of tests contained within.
 ' @param {function} func - the function to execute as part of this suite.
 ' @returns {assocarray} - the newly-created test suite -- state included.
 function __roca_describe(description as string, func as object)
+    return m.__createDescribeBlock("default", description, func)
+end function
+
+function __roca_fdescribe(description as string, func as object)
+    return m.__createDescribeBlock("focus", description, func)
+end function
+
+function __roca_xdescribe(description as string, func as object)
+    return m.__createDescribeBlock("skip", description, func)
+end function
+
+function __roca_createDescribeBlock(mode as string, description as string, func as object)
+    if mode <> "default" and mode <> "skip" and mode <> "focus" then
+        print "[roca.brs] Error: Received unexpected describe block mode'" mode "'"
+        return
+    end if
+
     suite = __roca_suite()
+    suite.mode = mode
     suite.__state.description = description
     suite.__state.func = func
 
     if m.__suite <> invalid then
+        if mode = "focus" then
+            m.__suite.__state.hasFocusedSuites = true
+        end if
+
+        suite.__state.hasFocusedAncestors = m.__suite.mode = "focus" or m.__suite.__state.hasFocusedAncestors
         suite.__state.parentSuite = m.__suite
         m.__suite.__registerSuite(suite)
     end if
@@ -37,11 +62,14 @@ function __roca_describe(description as string, func as object)
         it: __it
         fit: __fit
         xit: __xit
-        describe: __roca_describe
+        __createDescribeBlock: __roca_createDescribeBlock,
+        describe: __roca_describe,
+        fdescribe: __roca_fdescribe,
+        xdescribe: __roca_xdescribe,
     }
     withM.__func()
 
-    suite.__state.transitivelyHasFocusedCases = suite.__transitivelyHasFocusedCases()
+    suite.__state.hasFocusedDescendants = suite.__hasFocusedDescendants()
     suite.__state.totalCases = suite.__totalCases()
 
     ' start to execute tests only from the top-level describe
@@ -76,7 +104,9 @@ function __roca_suite()
             description: "",
             cases: [],
             hasFocusedCases: false,
-            transitivelyHasFocusedCases: false,
+            hasFocusedSuites: false,
+            hasFocusedDescendants: false,
+            hasFocusedAncestors: false,
             suites: [],
             results: {
                 passed: 0,
@@ -84,11 +114,13 @@ function __roca_suite()
                 skipped: 0
             }
         },
-        __transitivelyHasFocusedCases: __suite_transitivelyHasFocusedCases,
+        __hasFocusedDescendants: __suite_hasFocusedDescendants,
         __totalCases: __suite_totalCases,
         __registerSuite: __suite_registerSuite,
         __registerCase: __suite_registerCase,
+        __filterFocused: __suite_filterFocused,
         exec: __suite_exec,
+        mode: "",
     }
 end function
 
@@ -149,16 +181,20 @@ function __case_report(index as integer, tap as object) as string
     end if
 end function
 
-function __suite_transitivelyHasFocusedCases() as boolean
+function __suite_hasFocusedDescendants() as boolean
     for each suite in m.__state.suites
-        if suite.__state.hasFocusedCases = true then
+        if suite.mode = "focus" then
             return true
-        else if suite.__transitivelyHasFocusedCases() = true then
+        else if suite.__state.hasFocusedCases = true then
+            return true
+        else if suite.__state.hasFocusedSuites = true then
+            return true
+        else if suite.__hasFocusedDescendants() = true then
             return true
         end if
     end for
 
-    return m.__state.hasFocusedCases
+    return m.__state.hasFocusedCases or m.__state.hasFocusedSuites
 end function
 
 
@@ -178,8 +214,37 @@ sub __suite_registerSuite(suite)
     m.__state.suites.push(suite)
 end sub
 
+sub __suite_filterFocused()
+    ' If we have test cases or sub-suites that are in focus, only test those.
+    ' Otherwise, we can assume that we should test everything because we are in the focus chain.
+    if m.__state.hasFocusedDescendants then
+        focusedCases = []
+        for each testCase in m.__state.cases
+            if testCase.mode = "focus" then
+                focusedCases.push(testCase)
+            end if
+        end for
+
+        focusedSuites = []
+        for each suite in m.__state.suites
+            if suite.mode = "focus" or suite.__state.hasFocusedDescendants then
+                focusedSuites.push(suite)
+            end if
+        end for
+
+        m.__state.cases = focusedCases
+        m.__state.suites = focusedSuites
+    end if
+end sub
+
 sub __suite_exec(args as object)
     if args.exec <> true then return
+
+    if args.focusedCasesDetected then
+        if m.__state.hasFocusedAncestors <> true and m.__state.hasFocusedDescendants <> true and m.mode <> "focus" then return
+
+        m.__filterFocused()
+    end if
 
     tap = args.tap
     tap.enterSubTest(m.__state.description)
@@ -201,10 +266,8 @@ sub __suite_exec(args as object)
     index = subTestIndex
     for each case in m.__state.cases
         tap.indent()
-        if (args.focusedCasesDetected and case.mode = "focus") or not args.focusedCasesDetected then
-            if case.mode <> "skip" then
-                case.exec()
-            end if
+        if case.mode <> "skip" then
+            case.exec()
         end if
         result = case.report(index, tap)
         if result = "passed" then

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -50,6 +50,8 @@ function __roca_createDescribeBlock(mode as string, description as string, func 
         end if
 
         suite.__state.hasFocusedAncestors = m.__suite.mode = "focus" or m.__suite.__state.hasFocusedAncestors
+        suite.__state.hasSkippedAncestors = m.__suite.mode = "skip" or m.__suite.__state.hasSkippedAncestors
+
         suite.__state.parentSuite = m.__suite
         m.__suite.__registerSuite(suite)
     end if
@@ -107,6 +109,7 @@ function __roca_suite()
             hasFocusedSuites: false,
             hasFocusedDescendants: false,
             hasFocusedAncestors: false,
+            hasSkippedAncestors: false,
             suites: [],
             results: {
                 passed: 0,
@@ -266,7 +269,7 @@ sub __suite_exec(args as object)
     index = subTestIndex
     for each case in m.__state.cases
         tap.indent()
-        if m.mode <> "skip" and case.mode <> "skip" then
+        if case.mode <> "skip" and m.mode <> "skip" and m.__state.hasSkippedAncestors <> true then
             case.exec()
         end if
         result = case.report(index, tap)

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -266,7 +266,7 @@ sub __suite_exec(args as object)
     index = subTestIndex
     for each case in m.__state.cases
         tap.indent()
-        if case.mode <> "skip" then
+        if m.mode <> "skip" and case.mode <> "skip" then
             case.exec()
         end if
         result = case.report(index, tap)

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -37,7 +37,10 @@ sub main()
     for each file in files
         path = ["pkg:", basePath, file].join("/")
         suite = _brs_.runInScope(path, args)
-        args.index += 1
+
+        if focusedCasesDetected and suite.__state.hasFocusedDescendants then
+            args.index += 1
+        end if
     end for
 end sub
 

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -38,7 +38,9 @@ sub main()
         path = ["pkg:", basePath, file].join("/")
         suite = _brs_.runInScope(path, args)
 
-        if focusedCasesDetected and suite.__state.hasFocusedDescendants then
+        ' If there are focused cases, only update the index when we've run a focused root suite.
+        ' Otherwise, always update it.
+        if focusedCasesDetected <> true or suite.__state.hasFocusedDescendants then
             args.index += 1
         end if
     end for

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -9,14 +9,23 @@ sub main()
         if suite <> invalid then rootSuites.push(suite)
     end for
 
+    numFocusedSuites = 0
     focusedCasesDetected = false
     for each suite in rootSuites
-        focusedCasesDetected = (focusedCasesDetected or suite.__state.transitivelyHasFocusedCases)
+        if suite.__state.hasFocusedDescendants then
+            numFocusedSuites++
+            focusedCasesDetected = true
+        end if
     end for
 
     tap = tap()
     tap.version()
-    tap.plan(rootSuites.count())
+
+    if focusedCasesDetected then
+        tap.plan(numFocusedSuites)
+    else
+        tap.plan(rootSuites.count())
+    end if
 
     args = {
         exec: true,


### PR DESCRIPTION
# Change Summary
This implements `fdescribe` and `xdescribe` (#21).

Also, this modifies the existing focus logic so that we **ignore non-focused tests instead of skipping them**. This is the [same behavior as `mocha`](https://github.com/mochajs/mocha/blob/master/lib/suite.js#L459-L482), and makes test runs that use `fdescribe`/`fit` have much cleaner output.

fixes #21 