### PR TITLE
fix(assert): don't allow assert failures to be overwritten

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Just like [Mocha](https://mochajs.org/) tests are written in JavaScript, roca te
 2. That `main` function initializes a Roca instance by passing the arguments from (1) into `roca()`.
 3. That `main` function returns the return value of the `someRocaInstance.describe()` function 
 4. A test case declared with `m.it`
-5. The test case passes or fails with `m.pass()`, `m.fail()`, or an assertion that calls one of those
+5. The test case passes or fails with `m.pass()`, `m.fail()`, or an assertion that calls one of those.
 
 Put simply:
 
@@ -46,6 +46,29 @@ function main(args as object) as object
     return roca(args).describe("test suite", sub()
         m.it("has a test case", sub()
             m.pass()
+        end sub)
+    end sub)
+end function
+```
+
+### Asserts
+
+Similar to [Chai](https://www.chaijs.com/api/assert/), `roca` offers an `assert` library, available via `m.assert`. It has the following methods:
+
+- `m.assert.equal(actual, expected, errorMessage)`
+- `m.assert.notEqual(actual, expected, errorMessage)`
+- `m.assert.isTrue(value, errorMessage)`
+- `m.assert.isFalse(value, errorMessage)`
+- `m.assert.isInvalid(value, errorMessage)`
+
+These methods will call `m.pass` or `m.fail` for you.
+
+Usage:
+```brightscript
+function main(args as object) as object
+    return roca(args).describe("test suite", sub()
+        m.it("test case", sub()
+            m.assert.equal("foo", "foo", "foo equals foo")
         end sub)
     end sub)
 end function

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -298,7 +298,9 @@ end sub
 
 ' Forces a test case into a "success" state.
 sub __util_pass()
-    m.__state.success = true
+    if m.__state.success <> false
+        m.__state.success = true
+    end if
 end sub
 
 ' Forces a test case into a "failure" state.

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -297,6 +297,9 @@ sub __suite_exec(args as object)
 end sub
 
 ' Forces a test case into a "success" state.
+'
+' If the test case is already in a failure state, do nothing
+' to preserve the previous failure.
 sub __util_pass()
     if m.__state.success <> false
         m.__state.success = true
@@ -304,9 +307,14 @@ sub __util_pass()
 end sub
 
 ' Forces a test case into a "failure" state.
+'
+' If the test case is already in a failure state, do nothing
+' to preserve the previous failure.
 sub __util_fail(metadata = invalid)
-    m.__state.success = false
-    m.__state.metadata = metadata
+    if m.__state.success <> false
+        m.__state.success = false
+        m.__state.metadata = metadata
+    end if
 end sub
 
 ' Prints messages to stdout in a TAP-compliant format


### PR DESCRIPTION
# Change Summary
In the current state of the assert lib, multiple asserts will overwrite each other.
```
function main(args as object) as object
    return roca(args).describe("test suite", sub()
        m.it("test case", sub()
            m.assert.isTrue(false)        ' should cause the test case to fail
            m.assert.isTrue(true)         ' overwrites the previous assert, making the test case pass
        end sub)
    end sub)
end function
```
With this change, the first failure that the test case encounters will be preserved, and that message will show to the user.

Also, this updates the Readme with info about `assert`s.