### PR TITLE
feat: add support for a global setup file

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -41,14 +41,14 @@ const argv = require('yargs')
             await testRunner({
                 sourceDir: argv.s,
                 reporter: argv.reporter,
-                globalSetupFile: argv.g,
+                requireFilePath: argv.r,
             });
         }
     )
     .describe('s', 'Path to brs files (if different from source/)')
     .alias("s", "source")
-    .describe("g", "Path to a global setup file")
-    .alias("g", "global-setup")
+    .describe("r", "Path to a required setup file (will be run before unit tests)")
+    .alias("r", "require")
     .help("h")
     .alias("h", "help")
     .argv;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -40,12 +40,15 @@ const argv = require('yargs')
         async (argv) => {
             await testRunner({
                 sourceDir: argv.s,
-                reporter: argv.reporter
+                reporter: argv.reporter,
+                globalSetupFile: argv.g,
             });
         }
     )
     .describe('s', 'Path to brs files (if different from source/)')
     .alias("s", "source")
+    .describe("g", "Path to a global setup file")
+    .alias("g", "global-setup")
     .help("h")
     .alias("h", "help")
     .argv;

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,31 @@ Roca exclusively reports its state via the [Test Anything Protocol](http://testa
 
 Other output formats are available!  See `roca --help` for more details.
 
+### Using a test setup/helper file
+In order to enable custom unit test helper functions and/or unit test setup code, you can create a BrightScript file that will be run before any of your unit tests. Pass it to `roca` via the `-r`/`--require` flag.
+
+For example, say you wanted to define a helper function that you could call in any of your unit tests:
+```brs
+' inside myProject/test/MySetupFile.brs
+function callMeAnywhere()
+  return 123
+end function
+```
+
+Then in your code, you'd have:
+```brs
+' inside myProject/test/MyTestFile.test.brs
+...
+m.it("adds local and remote login buttons to page", sub()
+    print callMeAnywhere() ' => 123
+end sub)
+```
+
+And then you'd tell to `roca` to use the setup file:
+```bash
+roca -r "test/MySetupFile.brs"
+```
+
 ## API
 ### Global Functions
 #### `roca(args = {} as object) as object`

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ async function findBrsFiles(sourceDir) {
     return util.promisify(glob)(pattern);
 }
 
-async function runTest(files, reporter, globalSetupFile) {
+async function runTest(files, reporter, requireFilePath) {
     let rocaFiles = [
         "tap.brs",
         "roca_lib.brs",
@@ -21,8 +21,8 @@ async function runTest(files, reporter, globalSetupFile) {
     try {
         let reporterStream = new TapMochaReporter(reporter);
         let allTestFiles = [...rocaFiles];
-        if (globalSetupFile) {
-            allTestFiles.push(globalSetupFile);
+        if (requireFilePath) {
+            allTestFiles.push(requireFilePath);
         }
         allTestFiles.push(...files);
         await brs.execute(allTestFiles, {
@@ -37,7 +37,7 @@ async function runTest(files, reporter, globalSetupFile) {
 }
 
 module.exports = async function(options) {
-    let { sourceDir, reporter, globalSetupFile } = options;
+    let { sourceDir, reporter, requireFilePath } = options;
     let files = await findBrsFiles(sourceDir);
-    await runTest(files, reporter, globalSetupFile);
+    await runTest(files, reporter, requireFilePath);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ async function findBrsFiles(sourceDir) {
     return util.promisify(glob)(pattern);
 }
 
-async function runTest(files, reporter) {
+async function runTest(files, reporter, globalSetupFile) {
     let rocaFiles = [
         "tap.brs",
         "roca_lib.brs",
@@ -20,7 +20,12 @@ async function runTest(files, reporter) {
 
     try {
         let reporterStream = new TapMochaReporter(reporter);
-        await brs.execute([ ...rocaFiles, ...files], {
+        let allTestFiles = [...rocaFiles];
+        if (globalSetupFile) {
+            allTestFiles.push(globalSetupFile);
+        }
+        allTestFiles.push(...files);
+        await brs.execute(allTestFiles, {
             stdout: reporterStream,
             stderr: process.stderr
         });
@@ -32,7 +37,7 @@ async function runTest(files, reporter) {
 }
 
 module.exports = async function(options) {
-    let { sourceDir, reporter } = options;
+    let { sourceDir, reporter, globalSetupFile } = options;
     let files = await findBrsFiles(sourceDir);
-    await runTest(files, reporter);
+    await runTest(files, reporter, globalSetupFile);
 }


### PR DESCRIPTION
# Change Summary
This adds support for the user to supply a path to a global setup file. This is helpful for the user because often there are test utilities that are needed in multiple unit test files. But without a global setup file, the only way to create those utilities would be to have them in `source/`, which would mean they get bundled with the actual application.

This is pretty similar to, for example, Jest's [config option](https://jestjs.io/docs/en/configuration#globalsetup-string).