### PR TITLE
Allow a test file to return multiple suite objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,9 +131,9 @@
       }
     },
     "brs": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/brs/-/brs-0.17.2.tgz",
-      "integrity": "sha512-6oDRoFjY3oC/1z3t0+6gc6TwrcLc/LlwmZSGQB6HfPWTN9lxEUTjUiz5Yo5csqbPi0tQkuC9VyLcRidBzXVVjA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/brs/-/brs-0.24.0.tgz",
+      "integrity": "sha512-6d/id2p+WM14+5aSLTrso7FdoiTWpOcPXytWcX2U6IsEfNoRfSzDvZk4sNnCxXn9QPVFaRqC9oe9I91J1rVfVg==",
       "dev": true,
       "requires": {
         "commander": "^2.12.2",
@@ -400,25 +400,26 @@
       }
     },
     "fast-glob": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
-      "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.0",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
       }
     },
     "fastq": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
-      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
       "dev": true,
       "requires": {
-        "reusify": "^1.0.0"
+        "reusify": "^1.0.4"
       }
     },
     "fill-range": {
@@ -483,9 +484,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -676,9 +677,9 @@
       "dev": true
     },
     "luxon": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.21.3.tgz",
-      "integrity": "sha512-lLRwNcNnkZLuv13A1FUuZRZmTWF7ro2ricYvb0L9cvBYHPvZhQdKwrYnZzi103D2XKmlVmxWpdn2wfIiOt2YEw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.24.1.tgz",
+      "integrity": "sha512-CgnIMKAWT0ghcuWFfCWBnWGOddM0zu6c4wZAWmD0NN7MZTnro0+833DF6tJep+xlxRPg4KtsYEHYLfTMBQKwYg==",
       "dev": true
     },
     "map-cache": {
@@ -707,9 +708,9 @@
       }
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -938,9 +939,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
-    "brs": "^0.17.2"
+    "brs": "^0.24.0"
   },
   "peerDependencies": {
     "brs": "^0.17.2"

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -6,7 +6,11 @@ sub main()
     for each file in files
         path = ["pkg:", basePath, file].join("/")
         suite = _brs_.runInScope(path, {})
-        if suite <> invalid then rootSuites.push(suite)
+        if GetInterface(suite, "ifArray") <> invalid then
+            rootSuites.append(suite)
+        else if suite <> invalid then
+            rootSuites.push(suite)
+        end if
     end for
 
     numFocusedSuites = 0


### PR DESCRIPTION
This allows writing a test file like:
```brightscript
' group.test.brs
function main(args as object)
    r = roca(args)
    return [
        Command_spec(r),
        Util_spec(r)
    ]
end function
```

with test cases being collocated in the sources like:
```brightscript
' source/utils/Util.spec.brs
function Util_spec(roca)
    return roca.describe("Util suite", sub()
        m.it("should pass", sub()
            m.pass()
        end sub)
    end sub)
end function
```