### PR TITLE
feat(api): Allow passing fields to cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Just like [Mocha](https://mochajs.org/) tests are written in JavaScript, roca te
 
 1. A function called `main` that accepts one argument of type `object` and returns a value of type `object`
 2. That `main` function initializes a Roca instance by passing the arguments from (1) into `roca()`.
-3. That `main` function returns the return value of the `someRocaInstance.describe()` function 
+3. That `main` function returns the return value of the `someRocaInstance.describe()` function
 4. A test case declared with `m.it`
 5. The test case passes or fails with `m.pass()`, `m.fail()`, or an assertion that calls one of those.
 
@@ -211,13 +211,13 @@ m.describe("an unfocused test suite", sub()
     end sub)
 end sub)
 
-m.fdescribe("a focused test suite", sub() 
+m.fdescribe("a focused test suite", sub()
     m.it("a test case inside of a focused suite", sub()
         ' this test *will* be executed, because it's inside a focused suite
     end sub)
 
     ' This sub-suite will run, because it's inside of a focused suite
-    m.describe("a sub-suite", sub() 
+    m.describe("a sub-suite", sub()
         m.it("a test case inside of the sub-suite", sub()
             ' this test *will* be executed, because it has focused ancestors
         end sub)
@@ -240,7 +240,7 @@ m.xdescribe("an skipped test suite", sub()
     end sub)
 
     ' This sub-suite will be skipped, because it's inside of a skipped suite
-    m.describe("a sub-suite", sub() 
+    m.describe("a sub-suite", sub()
         m.it("a test case inside of the sub-suite", sub()
             ' this test will be skipped, because it has skipped ancestors
         end sub)
@@ -316,5 +316,30 @@ Example:
 ```brightscript
 m.it("fails", sub()
     m.fail()
+end sub)
+```
+
+#### `m.addContext(ctx as object)`
+Provides context to cases in the form of extra fields.
+
+- `ctx` should be a `roAssociativeArray`,
+- `m.addContext` should be called in the scope of `m.describe`'s `sub`,
+- `m.addContext` can be called multiple times,
+- Context cascades into sub-suites.
+
+Example:
+```brightscript
+m.describe("a test suite with context", sub()
+    m.addContext({
+        aField: "value 1"
+        afn: function()
+            return "value 2"
+        end function
+    })
+
+    m.it("a test case", sub()
+        m.assert.equal("value 1", m.aField, "Get context field")
+        m.assert.equal("value 2", m.aFunction(), "Use context function")
+    end sub)
 end sub)
 ```

--- a/README.md
+++ b/README.md
@@ -323,15 +323,17 @@ end sub)
 Provides context to cases in the form of extra fields.
 
 - `ctx` should be a `roAssociativeArray`,
-- `m.addContext` should be called in the scope of `m.describe`'s `sub`,
 - `m.addContext` can be called multiple times,
 - Context cascades into sub-suites.
 
 Example:
 ```brightscript
+m.addContext({
+    aField: "value 1"
+})
+
 m.describe("a test suite with context", sub()
     m.addContext({
-        aField: "value 1"
         afn: function()
             return "value 2"
         end function
@@ -339,7 +341,7 @@ m.describe("a test suite with context", sub()
 
     m.it("a test case", sub()
         m.assert.equal("value 1", m.aField, "Get context field")
-        m.assert.equal("value 2", m.aFunction(), "Use context function")
+        m.assert.equal("value 2", m.afn(), "Use context function")
     end sub)
 end sub)
 ```

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -14,7 +14,9 @@ function roca(args = {} as object)
         xdescribe: __roca_xdescribe,
         it: __it,
         fit: __fit,
-        xit: __xit
+        xit: __xit,
+        __ctx: {},
+        addContext: __roca_addContext
     }
 end function
 
@@ -55,13 +57,13 @@ function __roca_createDescribeBlock(mode as string, description as string, func 
         suite.__state.parentSuite = m.__suite
 
         ' cascade context
-        if m.__suite.__ctx <> invalid then
-            suite.__ctx = {}
-            suite.__ctx.append(m.__suite.__ctx)
-        end if
+        suite.__ctx.append(m.__suite.__ctx)
 
         m.__suite.__registerSuite(suite)
     end if
+
+    ' cascade roca context
+    if m.__ctx <> invalid then suite.__ctx.append(m.__ctx)
 
     ' package the suite up with its context accessible via `m.`
     withM = {
@@ -110,8 +112,11 @@ end sub
 sub __roca_addContext(ctx as object)
     if type(ctx) <> "roAssociativeArray" then
         print "[roca.brs] Error: addContext only accepts a 'roAssociativeArray' - got '" type(ctx) "'"
+    ' called from roca object
+    else if m.__ctx <> invalid then
+        m.__ctx.append(ctx)
+    ' called in suite
     else
-        if m.__suite.__ctx = invalid then m.__suite.__ctx = {}
         m.__suite.__ctx.append(ctx)
     end if
 end sub
@@ -141,6 +146,7 @@ function __roca_suite()
         __registerSuite: __suite_registerSuite,
         __registerCase: __suite_registerCase,
         __filterFocused: __suite_filterFocused,
+        __ctx: {},
         exec: __suite_exec,
         mode: "",
     }

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -68,6 +68,7 @@ function __roca_createDescribeBlock(mode as string, description as string, func 
         describe: __roca_describe,
         fdescribe: __roca_fdescribe,
         xdescribe: __roca_xdescribe,
+        addFields: __roca_addFields
     }
     withM.__func()
 
@@ -95,6 +96,16 @@ end sub
 
 sub __xit(description as string, func as object)
     m.__suite.__registerCase("skip", description, m.__suite, func)
+end sub
+
+' Fields to add to `m` in the case context.
+' @param fields a roAssociativeObject
+sub __roca_addFields(fields as object)
+    if type(fields) <> "roAssociativeArray" then
+        print "[roca.brs] Error: addFields only accepts a 'roAssociativeArray' - got '" type(fields) "'"
+    else
+        m.__suite.__fields = fields
+    end if
 end sub
 
 ' Creates a new test suite, which can contain an arbitrary number of test cases and sub-suites.
@@ -166,6 +177,14 @@ function __case_execute()
         __state: m.__state
         assert: assert(__util_pass, __util_fail, m.__state)
     }
+
+    ' extra case fields
+    if m.suite.__fields <> invalid then
+        for each item in m.suite.__fields.items()
+            withM.addreplace(item.key, item.value)
+        end for
+    end if
+
     withM.__func()
 end function
 

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -53,6 +53,13 @@ function __roca_createDescribeBlock(mode as string, description as string, func 
         suite.__state.hasSkippedAncestors = m.__suite.mode = "skip" or m.__suite.__state.hasSkippedAncestors
 
         suite.__state.parentSuite = m.__suite
+
+        ' cascade context
+        if m.__suite.__ctx <> invalid then
+            suite.__ctx = {}
+            suite.__ctx.append(m.__suite.__ctx)
+        end if
+
         m.__suite.__registerSuite(suite)
     end if
 
@@ -68,7 +75,7 @@ function __roca_createDescribeBlock(mode as string, description as string, func 
         describe: __roca_describe,
         fdescribe: __roca_fdescribe,
         xdescribe: __roca_xdescribe,
-        addFields: __roca_addFields
+        addContext: __roca_addContext
     }
     withM.__func()
 
@@ -99,12 +106,13 @@ sub __xit(description as string, func as object)
 end sub
 
 ' Fields to add to `m` in the case context.
-' @param fields a roAssociativeObject
-sub __roca_addFields(fields as object)
-    if type(fields) <> "roAssociativeArray" then
-        print "[roca.brs] Error: addFields only accepts a 'roAssociativeArray' - got '" type(fields) "'"
+' @param ctx a roAssociativeArray
+sub __roca_addContext(ctx as object)
+    if type(ctx) <> "roAssociativeArray" then
+        print "[roca.brs] Error: addContext only accepts a 'roAssociativeArray' - got '" type(ctx) "'"
     else
-        m.__suite.__fields = fields
+        if m.__suite.__ctx = invalid then m.__suite.__ctx = {}
+        m.__suite.__ctx.append(ctx)
     end if
 end sub
 
@@ -179,11 +187,7 @@ function __case_execute()
     }
 
     ' extra case fields
-    if m.suite.__fields <> invalid then
-        for each item in m.suite.__fields.items()
-            withM.addreplace(item.key, item.value)
-        end for
-    end if
+    if m.suite.__ctx <> invalid then withM.append(m.suite.__ctx)
 
     withM.__func()
 end function


### PR DESCRIPTION
```brightscript
function main(args as object) as object
    return roca(args).describe("test suite", sub()
        m.addContext({
            someValue: "value"
            beforeEach: function()
                 return { data: "data" }
            end function
        })

        m.it("has a test case", sub()
            o = m.beforeEach()
            m.assert.equal("data", o.data, "I can call a function")
            m.assert.equal("value", m.someValue, "I can get a value")
            m.pass()
        end sub)
    end sub)
end function
```

Maybe adresses issue #20 