### PR TITLE
fix(lib): bail after brs throws exception

### DIFF
--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -42,9 +42,15 @@ sub main()
         path = ["pkg:", basePath, file].join("/")
         suite = _brs_.runInScope(path, args)
 
+        ' If brs returned invalid for runInScope, that means the suite threw an exception, so we should bail.
+        if suite = invalid then
+            tap.bail()
+            return
+        end if
+
         ' If there are focused cases, only update the index when we've run a focused root suite.
         ' Otherwise, always update it.
-        if focusedCasesDetected <> true or (suite <> invalid and suite.__state.hasFocusedDescendants) then
+        if focusedCasesDetected <> true or suite.__state.hasFocusedDescendants then
             args.index += 1
         end if
     end for

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -44,7 +44,7 @@ sub main()
 
         ' If there are focused cases, only update the index when we've run a focused root suite.
         ' Otherwise, always update it.
-        if focusedCasesDetected <> true or suite.__state.hasFocusedDescendants then
+        if focusedCasesDetected <> true or (suite <> invalid and suite.__state.hasFocusedDescendants) then
             args.index += 1
         end if
     end for

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -44,7 +44,7 @@ sub main()
 
         ' If brs returned invalid for runInScope, that means the suite threw an exception, so we should bail.
         if suite = invalid then
-            tap.bail()
+            tap.bail("Error occurred in " + [basePath, file].join("/"))
             return
         end if
 

--- a/resources/tap.brs
+++ b/resources/tap.brs
@@ -17,6 +17,7 @@ function Tap() as object
         indent: __tap_indent,
         deindent: __tap_deindent,
         getIndent: __tap_getIndent,
+        bail: __tap_bail,
         __state: {
             depth: 0
         }
@@ -126,4 +127,8 @@ function __tap_getIndent()
         indent += "    "
     end for
     return indent
+end function
+
+function __tap_bail()
+    print "Bail out!"
 end function

--- a/resources/tap.brs
+++ b/resources/tap.brs
@@ -129,6 +129,6 @@ function __tap_getIndent()
     return indent
 end function
 
-function __tap_bail()
-    print "Bail out!"
+function __tap_bail(msg="" as string)
+    print "Bail out! " + msg
 end function


### PR DESCRIPTION
# Change Summary

When `brs.runInScope` fails due to an exception, it returns `invalid`. When that happens, we should bail on running the rest of the tests so that we don't print a bunch of `test count !== plan` errors. `Bail out!` is in the TAP specification for when you want your test to bail.
