### PR TITLE
feat(brs): reset mocks between test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
-    "brs": "^0.24.0",
+    "brs": "^0.25.0",
     "doctoc": "^1.4.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11"
   },
   "peerDependencies": {
-    "brs": "^0.17.2"
+    "brs": "^0.25.0"
   },
   "lint-staged": {
     "README.md": "doctoc"

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -39,6 +39,8 @@ sub main()
     }
 
     for each file in files
+        ' _brs_.resetMocks()
+
         path = ["pkg:", basePath, file].join("/")
         suite = _brs_.runInScope(path, args)
 

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -39,7 +39,7 @@ sub main()
     }
 
     for each file in files
-        ' _brs_.resetMocks()
+        _brs_.resetMocks()
 
         path = ["pkg:", basePath, file].join("/")
         suite = _brs_.runInScope(path, args)

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -39,6 +39,7 @@ sub main()
     }
 
     for each file in files
+        ' Don't allow test files to pollute each other
         _brs_.resetMocks()
 
         path = ["pkg:", basePath, file].join("/")


### PR DESCRIPTION
# Change summary

This calls [`_brs_.resetMocks`](https://github.com/sjbarag/brs#_brs_resetmocks) between test files to prevent test files from interfering with each other.

Unfortunately, there's no unit tests set up (yet!) for this project, but rest assured that I have tested this in a brightscript repo to confirm that it works as expected.