### PR TITLE
fix(dependencies): correct brs version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -284,9 +284,9 @@
       }
     },
     "brs": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/brs/-/brs-0.24.0.tgz",
-      "integrity": "sha512-6d/id2p+WM14+5aSLTrso7FdoiTWpOcPXytWcX2U6IsEfNoRfSzDvZk4sNnCxXn9QPVFaRqC9oe9I91J1rVfVg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/brs/-/brs-0.25.1.tgz",
+      "integrity": "sha512-26lbQxMdbl7afmAJLxOxoEeCWsPR3VcxwX6twW5ZMUrIBYgQvlY95zCjVzegBH3deC27OCkl5E7ezEe2hC3jdQ==",
       "dev": true,
       "requires": {
         "commander": "^2.12.2",


### PR DESCRIPTION
# Change Summary

Looks like we got out of sync with the `brs` version in the `package.json`/`package-lock.json`. This PR resolves that.