### PR TITLE
fix(lib): don't skip tests if brs throws an exception

### DIFF
--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -6,9 +6,15 @@ sub main()
     for each file in files
         path = ["pkg:", basePath, file].join("/")
         suite = _brs_.runInScope(path, {})
+
+        if suite = invalid then
+            print "Error running tests: Runtime exception occurred in " + [basePath, file].join("/")
+            return
+        end if
+
         if GetInterface(suite, "ifArray") <> invalid then
             rootSuites.append(suite)
-        else if suite <> invalid then
+        else
             rootSuites.push(suite)
         end if
     end for


### PR DESCRIPTION
# Change Summary

Currently, if there is an error in the `m.describe` block, we do nothing on the first (non-exec) pass when the error is encountered, and then silently skip the entire file on the second (exec) pass. This is pretty confusing for the user, _especially_ if they are using `m.fdescribe` or `m.fit`, and suddenly we're running every test except for the (broken) focused ones.

This doesn't happen for code inside of `m.it` blocks or actual code that's being tested, because we don't execute that code until our second pass.

Let's fail early when we encounter a runtime exception.