### PR TITLE
feat(api): make context accessible from suite objects

### DIFF
--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -115,9 +115,15 @@ sub __roca_addContext(ctx as object)
     ' called from roca object
     else if m.__ctx <> invalid then
         m.__ctx.append(ctx)
+
+        ' make context immediately accessible in roca object
+        m.append(ctx)
     ' called in suite
     else
         m.__suite.__ctx.append(ctx)
+
+        ' make context immediately accessible in the suite
+        m.append(ctx)
     end if
 end sub
 


### PR DESCRIPTION
# Change Summary

`m.addContext(ctx)` appends everything in `ctx` to `m` object so that it's accessible within test cases. However, it currently isn't accessible in suites or the `roca` object. This PR makes it accessible from suites/`roca`.