### PR TITLE
fix(api): make fdescribe work on roca object

### DIFF
--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -22,7 +22,7 @@ sub main()
     numFocusedSuites = 0
     focusedCasesDetected = false
     for each suite in rootSuites
-        if suite.__state.hasFocusedDescendants then
+        if suite.mode = "focus" or suite.__state.hasFocusedDescendants then
             numFocusedSuites++
             focusedCasesDetected = true
         end if


### PR DESCRIPTION
# Change Summary

Currently, if you do `roca(args).fdescribe( ... )` it doesn't focus correctly on that suite. This PR fixes that.