### PR TITLE
feat(cli): add --forbid-focused flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
     - [Adding a Test](#adding-a-test)
     - [Asserts](#asserts)
     - [Output & CI Support](#output--ci-support)
-    - [Using a test setup/helper file](#using-a-test-setuphelper-file)
+      - [CLI Options](#cli-options)
+        - [`-r`/`--require`](#-r--require)
   - [API](#api)
     - [Global Functions](#global-functions)
       - [`roca(args = {} as object) as object`](#rocaargs---as-object-as-object)
@@ -134,9 +135,17 @@ end function
 ### Output & CI Support
 Roca exclusively reports its state via the [Test Anything Protocol](http://testanything.org/), and defaults to a Mocha-like "spec" output.  Failed tests cause the `roca` CLI to return a non-zero exit code, which allows most continuous integration systems to automatically detect pass/fail states.
 
-Other output formats are available!  See `roca --help` for more details.
+#### CLI Options
 
-### Using a test setup/helper file
+| Option                  | Behavior       |
+| ------------------------|----------------|
+| `-h`/`--help`           | The help menu. |
+| `-s`/`--source`         | Path to brs files (if different from source/) |
+| `-R`/`--reporter`       | The mocha reporter to use, via [`tap-mocha-reporter`](https://github.com/tapjs/tap-mocha-reporter). See `--help` for options. |
+| `-r`/`--require`        |  Path to a required setup file (will be run before unit tests) |
+| `-f`/`--forbid-focused` | Fail if focused test or suite is detected. |
+
+##### `-r`/`--require`
 In order to enable custom unit test helper functions and/or unit test setup code, you can create a BrightScript file that will be run before any of your unit tests. Pass it to `roca` via the `-r`/`--require` flag.
 
 For example, say you wanted to define a helper function that you could call in any of your unit tests:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ end function
 ### Output & CI Support
 Roca exclusively reports its state via the [Test Anything Protocol](http://testanything.org/), and defaults to a Mocha-like "spec" output.  Failed tests cause the `roca` CLI to return a non-zero exit code, which allows most continuous integration systems to automatically detect pass/fail states.
 
+Other output formats are available!  See `roca --help` for more details.
+
 #### CLI Options
 
 | Option                  | Behavior       |

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,13 +42,16 @@ const argv = require('yargs')
                 sourceDir: argv.s,
                 reporter: argv.reporter,
                 requireFilePath: argv.r,
+                forbidFocused: argv.f
             });
         }
     )
-    .describe('s', 'Path to brs files (if different from source/)')
+    .describe("s", "Path to brs files (if different from source/)")
     .alias("s", "source")
     .describe("r", "Path to a required setup file (will be run before unit tests)")
     .alias("r", "require")
+    .describe("f", "Fail if focused test or suite is encountered")
+    .alias("f", "--forbid-focused")
     .help("h")
     .alias("h", "help")
     .argv;

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,8 +161,7 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-escapes": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/hulu/roca#readme",
   "dependencies": {
+    "ansi-colors": "^4.1.1",
     "glob": "^7.1.4",
     "tap-mocha-reporter": "^5.0.0",
     "yargs": "^13.2.4"

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -29,16 +29,16 @@ function main() as object
     tap = tap()
     tap.version()
 
-    numFocusedCases = filesWithFocusedCases.count()
+    focusedCasesDetected = filesWithFocusedCases.count() > 0
     if focusedCasesDetected then
-        tap.plan(numFocusedCases)
+        tap.plan(filesWithFocusedCases.count())
     else
         tap.plan(rootSuites.count())
     end if
 
     args = {
         exec: true,
-        focusedCasesDetected: numFocusedCases > 0
+        focusedCasesDetected: focusedCasesDetected
         index: 0,
         tap: tap
     }

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -29,16 +29,16 @@ function main() as object
     tap = tap()
     tap.version()
 
-    focusedCasesDetected = filesWithFocusedCases.count() > 0
+    numFocusedCases = filesWithFocusedCases.count()
     if focusedCasesDetected then
-        tap.plan(filesWithFocusedCases.count())
+        tap.plan(numFocusedCases)
     else
         tap.plan(rootSuites.count())
     end if
 
     args = {
         exec: true,
-        focusedCasesDetected: focusedCasesDetected,
+        focusedCasesDetected: numFocusedCases > 0
         index: 0,
         tap: tap
     }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const glob = require('glob');
 const path = require('path');
 const util = require('util');
 const TapMochaReporter = require('tap-mocha-reporter');
+const c = require("ansi-colors");
 
 async function findBrsFiles(sourceDir) {
     let searchDir = sourceDir || 'source';
@@ -10,7 +11,8 @@ async function findBrsFiles(sourceDir) {
     return util.promisify(glob)(pattern);
 }
 
-async function runTest(files, reporter, requireFilePath) {
+async function runTest(files, options) {
+    let { reporter, requireFilePath, forbidFocused } = options;
     let rocaFiles = [
         "tap.brs",
         "roca_lib.brs",
@@ -25,19 +27,35 @@ async function runTest(files, reporter, requireFilePath) {
             allTestFiles.push(requireFilePath);
         }
         allTestFiles.push(...files);
-        await brs.execute(allTestFiles, {
+        let returnVals = await brs.execute(allTestFiles, {
             stdout: reporterStream,
             stderr: process.stderr
         });
+
         reporterStream.end();
+
+        if (forbidFocused && returnVals.length > 0) {
+            // iterate through return values and find usesfitorfdescribe from roca_main
+            for (output of returnVals) {
+                let focusedFiles = output.getValue().get("fileswithfocusedcases").getElements();
+                if (focusedFiles.length > 0) {
+                    let formattedList = focusedFiles.map((brsStringPath) => `    ${brsStringPath.value}`).join("/n");
+                    console.error(c.red(`Error: used command line arg ${c.cyan("--forbid-focused")} but found focused tests in these files:`));
+                    console.error(formattedList);
+
+                    process.exitCode = 1;
+                    return;
+                }
+            }
+        }
     } catch(e) {
         console.error("Interpreter found an error: ", e);
         process.exitCode = 1;
     }
 }
 
-module.exports = async function(options) {
-    let { sourceDir, reporter, requireFilePath } = options;
+module.exports = async function(args) {
+    let { sourceDir, ...options } = args;
     let files = await findBrsFiles(sourceDir);
-    await runTest(files, reporter, requireFilePath);
+    await runTest(files, options);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -37,13 +37,16 @@ async function runTest(files, options) {
         if (forbidFocused && returnVals.length > 0) {
             // iterate through return values and see if there are focused cases
             for (output of returnVals) {
-                let focusedFiles = output.getValue().get("fileswithfocusedcases").getElements();
-                if (focusedFiles.length > 0) {
-                    let formattedList = focusedFiles.map((brsStringPath) => `\t${brsStringPath.value}`).join("\n");
-                    console.error(c.red(`Error: used command line arg ${c.cyan("--forbid-focused")} but found focused tests in these files:\n${formattedList}`));
+                let maybeFiles = output.getValue().get("fileswithfocusedcases");
+                if (maybeFiles) {
+                    let focusedFiles = maybeFiles.getElements();
+                    if (focusedFiles.length > 0) {
+                        let formattedList = focusedFiles.map((brsStringPath) => `\t${brsStringPath.value}`).join("\n");
+                        console.error(c.red(`Error: used command line arg ${c.cyan("--forbid-focused")} but found focused tests in these files:\n${formattedList}`));
 
-                    process.exitCode = 1;
-                    return;
+                        process.exitCode = 1;
+                        return;
+                    }
                 }
             }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ async function runTest(files, options) {
         reporterStream.end();
 
         if (forbidFocused && returnVals.length > 0) {
-            // iterate through return values and find usesfitorfdescribe from roca_main
+            // iterate through return values and see if there are focused cases
             for (output of returnVals) {
                 let focusedFiles = output.getValue().get("fileswithfocusedcases").getElements();
                 if (focusedFiles.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-const brs = require('brs');
-const glob = require('glob');
-const path = require('path');
-const util = require('util');
-const TapMochaReporter = require('tap-mocha-reporter');
+const brs = require("brs");
+const glob = require("glob");
+const path = require("path");
+const util = require("util");
+const TapMochaReporter = require("tap-mocha-reporter");
 const c = require("ansi-colors");
 
 async function findBrsFiles(sourceDir) {
-    let searchDir = sourceDir || 'source';
-    const pattern = path.join(searchDir, '**', '*.brs');
+    let searchDir = sourceDir || "source";
+    const pattern = path.join(searchDir, "**", "*.brs");
     return util.promisify(glob)(pattern);
 }
 
@@ -39,9 +39,8 @@ async function runTest(files, options) {
             for (output of returnVals) {
                 let focusedFiles = output.getValue().get("fileswithfocusedcases").getElements();
                 if (focusedFiles.length > 0) {
-                    let formattedList = focusedFiles.map((brsStringPath) => `    ${brsStringPath.value}`).join("/n");
-                    console.error(c.red(`Error: used command line arg ${c.cyan("--forbid-focused")} but found focused tests in these files:`));
-                    console.error(formattedList);
+                    let formattedList = focusedFiles.map((brsStringPath) => `\t${brsStringPath.value}`).join("\n");
+                    console.error(c.red(`Error: used command line arg ${c.cyan("--forbid-focused")} but found focused tests in these files:\n${formattedList}`));
 
                     process.exitCode = 1;
                     return;


### PR DESCRIPTION
# Change Summary

This allows a consumer to pass `--forbid-focused` to the `roca` cli, which will then cause the test runner to exit with error if it detects a focused test case, i.e. it emulates the [Mocha cli `--forbid-only`](https://mochajs.org/#command-line-usage). This is useful to be able to configure CI/CD to avoid accidentally checking in focused tests/suites.