### PR TITLE
feat(api): Add `m.it_each` to support for parameterized tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
       - [`m.beforeEach(func as object)`](#mbeforeeachfunc-as-object)
       - [`m.afterEach(func as object)`](#maftereachfunc-as-object)
       - [`m.it(description as string, func as object, args = invalid as dynamic)`](#mitdescription-as-string-func-as-object-args--invalid-as-dynamic)
-      - [`m.fit(description as string, func as object, args = invalid as dynamic))`](#mfitdescription-as-string-func-as-object-args--invalid-as-dynamic)
-      - [`m.xit(description as string, func as object, args = invalid as dynamic))`](#mxitdescription-as-string-func-as-object-args--invalid-as-dynamic)
+      - [`m.fit(description as string, func as object)`](#mfitdescription-as-string-func-as-object)
+      - [`m.xit(description as string, func as object)`](#mxitdescription-as-string-func-as-object)
       - [`m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
       - [`m.fit_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mfit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
       - [`m.xit_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mxit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
@@ -363,6 +363,7 @@ Creates a focused test case &mdash; a test case that causes all non-focused test
 Parameters:
 * `description as string` - a string describing the test case executed by `func`
 * `func as object` - the function to execute as part of this test case
+* `args = invalid as dynamic` - optional parameter that will be passed in `func` as an argument
 
 Example:
 ```brightscript
@@ -386,6 +387,7 @@ Creates a skipped unit test case.  It will never execute.
 Parameters:
 * `description as string` - a string describing the test case executed by `func`
 * `func as object` - the (skipped) function to execute as part of this test case
+* `args = invalid as dynamic` - optional parameter that will be passed in `func` as an argument
 
 Example:
 ```brightscript

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@
       - [`m.xdescribe(description as string, func as object)`](#mxdescribedescription-as-string-func-as-object)
       - [`m.beforeEach(func as object)`](#mbeforeeachfunc-as-object)
       - [`m.afterEach(func as object)`](#maftereachfunc-as-object)
-      - [`m.it(description as string, func as object)`](#mitdescription-as-string-func-as-object)
+      - [`m.it(description as string, func as object, args = invalid as dynamic)`](#mitdescription-as-string-func-as-object-args--invalid-as-dynamic)
+      - [`m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mit_each(arrayOfArgs-as-object-descriptionGenerator-as-object-func-as-object))
       - [`m.fit(description as string, func as object)`](#mfitdescription-as-string-func-as-object)
       - [`m.xit(description as string, func as object)`](#mxitdescription-as-string-func-as-object)
       - [`m.log(value as dynamic)`](#mlogvalue-as-dynamic)
@@ -331,12 +332,13 @@ m.describe("a test suite", sub()
 end sub)
 ```
 
-#### `m.it(description as string, func as object)`
+#### `m.it(description as string, func as object, args = invalid as dynamic)`
 Creates a test case with a given description.
 
 Parameters:
 * `description as string` - a string describing the test case executed by `func`
 * `func as object` - the function to execute as part of this test case
+* `args = invalid as dynamic` - optional parameter that will be passed in `func` as an argument
 
 Example:
 ```brightscript
@@ -346,6 +348,32 @@ m.it("a test case", sub()
     else
         m.fail()
     end if
+end sub)
+
+m.it("a test case with args", sub(count)
+    if count > 0 then m.pass() else m.fail()
+end sub, 10)
+```
+
+#### `m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`
+Creates a parameterized test cases with generated description.
+
+Parameters:
+* `arrayOfArgs as object` - the array of args that will be passed in `func`
+* `descriptionGenerator as object` - a function that generate description string
+* `func as object` - the function to execute as part of this test case
+
+Example:
+```
+m.it_each([
+    [1, 1],
+    [2, 1],
+],
+function (args)
+    return substitute("compare {0} with {1}", args[0].tostr(), args[1].tostr())
+end function,
+sub(args)
+    if args[0] = args[1] then m.pass() else m.fail()
 end sub)
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
       - [`m.beforeEach(func as object)`](#mbeforeeachfunc-as-object)
       - [`m.afterEach(func as object)`](#maftereachfunc-as-object)
       - [`m.it(description as string, func as object, args = invalid as dynamic)`](#mitdescription-as-string-func-as-object-args--invalid-as-dynamic)
-      - [`m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mit_each(arrayOfArgs-as-object-descriptionGenerator-as-object-func-as-object))
+      - [`m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
       - [`m.fit(description as string, func as object)`](#mfitdescription-as-string-func-as-object)
       - [`m.xit(description as string, func as object)`](#mxitdescription-as-string-func-as-object)
       - [`m.log(value as dynamic)`](#mlogvalue-as-dynamic)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@
       - [`m.beforeEach(func as object)`](#mbeforeeachfunc-as-object)
       - [`m.afterEach(func as object)`](#maftereachfunc-as-object)
       - [`m.it(description as string, func as object, args = invalid as dynamic)`](#mitdescription-as-string-func-as-object-args--invalid-as-dynamic)
+      - [`m.fit(description as string, func as object, args = invalid as dynamic))`](#mfitdescription-as-string-func-as-object-args--invalid-as-dynamic)
+      - [`m.xit(description as string, func as object, args = invalid as dynamic))`](#mxitdescription-as-string-func-as-object-args--invalid-as-dynamic)
       - [`m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
-      - [`m.fit(description as string, func as object)`](#mfitdescription-as-string-func-as-object)
-      - [`m.xit(description as string, func as object)`](#mxitdescription-as-string-func-as-object)
+      - [`m.fit_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mfit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
+      - [`m.xit_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mxit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
       - [`m.log(value as dynamic)`](#mlogvalue-as-dynamic)
       - [`m.addContext(ctx as object)`](#maddcontextctx-as-object)
     - [Within a Test Case](#within-a-test-case)
@@ -355,28 +357,6 @@ m.it("a test case with args", sub(count)
 end sub, 10)
 ```
 
-#### `m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`
-Creates a parameterized test cases with generated description.
-
-Parameters:
-* `arrayOfArgs as object` - the array of args that will be passed in `func`
-* `descriptionGenerator as object` - a function that generate description string
-* `func as object` - the function to execute as part of this test case
-
-Example:
-```
-m.it_each([
-    [1, 1],
-    [2, 1],
-],
-function (args)
-    return substitute("compare {0} with {1}", args[0].tostr(), args[1].tostr())
-end function,
-sub(args)
-    if args[0] = args[1] then m.pass() else m.fail()
-end sub)
-```
-
 #### `m.fit(description as string, func as object)`
 Creates a focused test case &mdash; a test case that causes all non-focused tests *in all files* to be skipped.  Useful when debugging specific unit tests.
 
@@ -409,8 +389,74 @@ Parameters:
 
 Example:
 ```brightscript
-m.xit("a focused test case", sub()
+m.xit("a omitted test case", sub()
     m.fail() ' this test will never be executed, so it doesn't matter if it's explicitly failed
+end sub)
+```
+
+#### `m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`
+Creates a parameterized test cases with generated description.
+Will be expanded as `m.it` in for cycle with the passing argument to `func` from arguments array  
+
+Parameters:
+* `arrayOfArgs as object` - the array of args that will be passed in `func`
+* `descriptionGenerator as object` - a function that generate description string
+* `func as object` - the array of args, these args will be passed in `func`
+
+Example:
+```
+m.it_each([
+    [1, 1],
+    [2, 1],
+],
+function (args)
+    return substitute("compare {0} with {1}", args[0].tostr(), args[1].tostr())
+end function,
+sub(args)
+    if args[0] = args[1] then m.pass() else m.fail()
+end sub)
+```
+
+#### `m.fit_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`
+Creates a parameterized test cases with generated description.
+Will be expanded as `m.fit` in for cycle with the passing argument to `func` from arguments array  
+
+Parameters:
+* `arrayOfArgs as object` - the array of args that will be passed in `func`
+* `descriptionGenerator as object` - a function that generate description string
+* `func as object` - the array of args, these args will be passed in `func`
+
+Example:
+```
+m.fit_each([
+    [1, 1],
+    [2, 1],
+],
+function (args)
+    return substitute("focused test, compare {0} with {1}", args[0].tostr(), args[1].tostr())
+end function,
+sub(args)
+    if args[0] = args[1] then m.pass() else m.fail()
+end sub)
+```
+
+#### `m.xit_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`
+Creates a parameterized test cases with generated description.
+Will be expanded as `m.xit` in for cycle with the passing argument to `func` from arguments array  
+
+Parameters:
+* `arrayOfArgs as object` - the array of args that will be passed in `func`
+* `descriptionGenerator as object` - a function that generate description string
+* `func as object` - the array of args, these args will be passed in `func`
+
+Example:
+```
+m.xit_each([1, 2, 3],
+function (args)
+    return "omitted parameterized test case" 
+end function,
+sub(args)
+    m.fail()' this test will never be executed, so it doesn't matter if it's explicitly failed
 end sub)
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
       - [`m.beforeEach(func as object)`](#mbeforeeachfunc-as-object)
       - [`m.afterEach(func as object)`](#maftereachfunc-as-object)
       - [`m.it(description as string, func as object, args = invalid as dynamic)`](#mitdescription-as-string-func-as-object-args--invalid-as-dynamic)
-      - [`m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mit_eacharrayofargs-as-object-descriptiongenerator-as-object-func-as-object)
+      - [`m.it_each(arrayOfArgs as object, descriptionGenerator as object, func as object)`](#mit_each(arrayOfArgs-as-object-descriptionGenerator-as-object-func-as-object))
       - [`m.fit(description as string, func as object)`](#mfitdescription-as-string-func-as-object)
       - [`m.xit(description as string, func as object)`](#mxitdescription-as-string-func-as-object)
       - [`m.log(value as dynamic)`](#mlogvalue-as-dynamic)

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -15,7 +15,9 @@ function roca(args = {} as object)
         it: __it,
         it_each: __it_each,
         fit: __fit,
+        ft_each: __ft_each,
         xit: __xit,
+        xt_each: __xt_each,
         __ctx: {},
         addContext: __roca_addContext,
         __state: {
@@ -89,7 +91,9 @@ function __roca_createDescribeBlock(mode as string, description as string, func 
         it: __it
         it_each: __it_each
         fit: __fit
+        fit_each: __fit_each
         xit: __xit
+        xit_each: __xit_each
         __createDescribeBlock: __roca_createDescribeBlock,
         describe: __roca_describe,
         fdescribe: __roca_fdescribe,

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -115,7 +115,7 @@ end function
 ' Creates a test case with a given description.
 ' @param description a string describing this test case
 ' @param func the function to execute as part of this test case
-' @param optional parameter that will be passed in func as an argument
+' @param args optional parameter that will be passed in func as an argument
 sub __it(description as string, func as object, args = invalid as dynamic)
     m.__suite.__registerCase("default", description, m.__suite, func, args)
 end sub
@@ -218,6 +218,7 @@ end function
 ' @param description a string describing the test case
 ' @param suite the suite from the parent 'describe', used to track test pass and fail states
 ' @param func the function to execute as part of the test case
+' @param args object/value that will be passed in func as an argument if it is not `invalid`
 sub __suite_registerCase(mode as string, description as string, suite as object, func as object, args as dynamic)
     if mode <> "default" and mode <> "skip" and mode <> "focus" then
         print "[roca.brs] Error: Received unexpected test case mode '" mode "'"

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -115,6 +115,7 @@ end function
 ' Creates a test case with a given description.
 ' @param description a string describing this test case
 ' @param func the function to execute as part of this test case
+' @param optional parameter that will be passed in func as an argument
 sub __it(description as string, func as object, args = invalid as dynamic)
     m.__suite.__registerCase("default", description, m.__suite, func, args)
 end sub
@@ -129,7 +130,19 @@ end sub
 
 sub __it_each(argsArray as object, descriptionGenerator as object, func as object)
     for each args in argsArray
-        m.__suite.__registerCase("default", descriptionGenerator(args), m.__suite, func, args)
+        m.it(descriptionGenerator(args), func, args)
+    end for
+end sub
+
+sub __fit_each(argsArray as object, descriptionGenerator as object, func as object)
+    for each args in argsArray
+        m.fit(descriptionGenerator(args), func, args)
+    end for
+end sub
+
+sub __xit_each(argsArray as object, descriptionGenerator as object, func as object)
+    for each args in argsArray
+        m.xit(descriptionGenerator(args), func, args)
     end for
 end sub
 

--- a/test/parameterized/fit_each/tests/01-fit_each.test.brs
+++ b/test/parameterized/fit_each/tests/01-fit_each.test.brs
@@ -1,0 +1,24 @@
+function main(args as object) as object
+    return roca(args).fdescribe("root", sub()
+        m.fit_each([
+                { name: "case 1", in: "lorem", out: "LOREM" },
+                { name: "case 2", in: "iPsUm", out: "IPSUM" },
+                { name: "case 3", in: "DoLoR", out: "DOLOR" }
+            ], function(args) : return args.name : end function,
+            sub (args)
+                m.assert.equal(ucase(args.in), args.out, "String '" + args.in + "' must uppercase to '" + args.out + "'")
+            end sub
+        )
+
+        m.it_each([
+                ' these would all fail if they ran
+                { name: "case 1", in: "lorem", out: "lorem" },
+                { name: "case 2", in: "iPsUm", out: "ipsum" },
+                { name: "case 3", in: "DoLoR", out: "dolor" }
+            ], function(args) : return args.name : end function,
+            sub (args)
+                m.assert.equal(ucase(args.in), args.out, "String '" + args.in + "' must uppercase to '" + args.out + "'")
+            end sub
+        )
+    end sub)
+end function

--- a/test/parameterized/it_each/tests/01-it_each.test.brs
+++ b/test/parameterized/it_each/tests/01-it_each.test.brs
@@ -1,0 +1,13 @@
+function main(args as object) as object
+    return roca(args).fdescribe("root", sub()
+        m.it_each([
+                { name: "case 1", in: "lorem", out: "LOREM" },
+                { name: "case 2", in: "iPsUm", out: "IPSUM" },
+                { name: "case 3", in: "DoLoR", out: "DOLOR" }
+            ], function(args) : return args.name : end function,
+            sub (args)
+                m.assert.equal(ucase(args.in), args.out, "String '" + args.in + "' must uppercase to '" + args.out + "'")
+            end sub
+        )
+    end sub)
+end function

--- a/test/parameterized/parameterized.test.js
+++ b/test/parameterized/parameterized.test.js
@@ -1,0 +1,55 @@
+const { rocaInDir } = require("../util");
+
+describe("parameterized tests", () => {
+    test("it_each", async () => {
+        let results = await rocaInDir(__dirname, "it_each");
+
+        expect(results.stats).toMatchObject({
+            suites: 1,
+            tests: 3,
+            passes: 3,
+            pending: 0,
+            failures: 0
+        });
+
+        expect(results.passes).toMatchObject([
+            { fullTitle: "root case 1" },
+            { fullTitle: "root case 2" },
+            { fullTitle: "root case 3" },
+        ]);
+    });
+
+    test("fit_each", async () => {
+        let results = await rocaInDir(__dirname, "fit_each");
+
+        expect(results.stats).toMatchObject({
+            suites: 1,
+            tests: 3,
+            passes: 3,
+            pending: 0,
+            failures: 0
+        });
+
+        expect(results.passes).toMatchObject([
+            { fullTitle: "root case 1" },
+            { fullTitle: "root case 2" },
+            { fullTitle: "root case 3" },
+        ]);
+    });
+
+    test("xit_each", async () => {
+        let results = await rocaInDir(__dirname, "xit_each");
+
+        expect(results.stats).toMatchObject({
+            suites: 1,
+            tests: 4,
+            passes: 1,
+            pending: 3,
+            failures: 0
+        });
+
+        expect(results.passes).toMatchObject([
+            { fullTitle: "root ignores xit_each" },
+        ]);
+    });
+});

--- a/test/parameterized/xit_each/tests/01-xit_each.test.brs
+++ b/test/parameterized/xit_each/tests/01-xit_each.test.brs
@@ -1,0 +1,18 @@
+function main(args as object) as object
+    return roca(args).fdescribe("root", sub()
+        m.it("ignores xit_each", sub()
+            m.pass()
+        end sub)
+
+        m.xit_each([
+                ' these would all fail if they ran
+                { name: "case 1", in: "lorem", out: "lorem" },
+                { name: "case 2", in: "iPsUm", out: "ipsum" },
+                { name: "case 3", in: "DoLoR", out: "dolor" }
+            ], function(args) : return args.name : end function,
+            sub (args)
+                m.assert.equal(ucase(args.in), args.out, "String '" + args.in + "' must uppercase to '" + args.out + "'")
+            end sub
+        )
+    end sub)
+end function


### PR DESCRIPTION
- Added `m.it_each` feature
- Updated `m.it`, now we can pass args to passed function.
- Updated README.md

closes #47 