### PR TITLE
fix(api): Make before/after each nested calls work correctly

### DIFF
--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -237,8 +237,7 @@ function __case_execute()
     ' extra case fields
     if m.suite.__ctx <> invalid then withM.append(m.suite.__ctx)
 
-    for i = 0 to m.__beforeExec.count()
-        fn = m.__beforeExec[i]
+    for each fn in m.__beforeExec
         if fn <> invalid and type(fn) = "Function" then
             ' execute the beforeEach using the test case `m` scope
             withM.__beforeExec = fn
@@ -251,8 +250,7 @@ function __case_execute()
 
     withM.__func()
 
-    for i = 0 to m.__afterExec.count()
-        fn = m.__afterExec[i]
+    for each fn in m.__afterExec
         if fn <> invalid and type(fn) = "Function" then
             ' execute the beforeEach using the test case `m` scope
             withM.__afterExec = fn

--- a/test/before-after/after-each/tests/01-nested.test.brs
+++ b/test/before-after/after-each/tests/01-nested.test.brs
@@ -1,0 +1,67 @@
+function main(args as object) as object
+    return roca(args).describe("nested root", sub()
+        m.addContext({
+            counterB: 0
+        })
+
+        m.afterEach(sub()
+            ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+            ' and are being done here as part of testing the test framework; please don't view this as
+            ' tacit approval to do the same in production tests :)
+            if m.__suite.__ctx.counterB <> invalid then m.__suite.__ctx.counterB++
+            m.append(m.__suite.__ctx)
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 3, "counterB must be incremented for each test case")
+        end sub)
+
+        m.it("case 2", sub()
+            m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 4, "counterB must be incremented for each test case")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; afterEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 5, "counterB must be incremented for each test case")
+        end sub)
+
+        m.describe("suite 1", sub()
+            m.addContext({
+                counterC: 0
+            })
+
+            m.afterEach(sub()
+                ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+                ' and are being done here as part of testing the test framework; please don't view this as
+                ' tacit approval to do the same in production tests :)
+                if m.__suite.__ctx.counterC <> invalid then m.__suite.__ctx.counterC++
+                m.append(m.__suite.__ctx)
+            end sub)
+
+            m.it("case 1.1", sub()
+                m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 0, "counterC must be incremented for each test case")
+            end sub)
+
+            m.it("case 1.2", sub()
+                m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 1, "counterC must be incremented for each test case")
+            end sub)
+
+            m.xit("skipped case", sub()
+                ' intentionally empty; afterEach() function shouldn't be called for this case
+            end sub)
+
+            m.it("case 1.3", sub()
+                m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 2, "counterC must be incremented for each test case")
+            end sub)
+        end sub)
+    end sub)
+end function

--- a/test/before-after/after-each/tests/02-single-level.test.brs
+++ b/test/before-after/after-each/tests/02-single-level.test.brs
@@ -19,7 +19,6 @@ function main(args as object) as object
             m.inScopeValue = "in-scope"
             m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
             m.assert.equal(m.counterA, 0, "counterA must be incremented for each test case")
-            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in afterEach")
         end sub)
 
         m.it("case 2", sub()
@@ -27,7 +26,6 @@ function main(args as object) as object
             m.inScopeValue = "in-scope"
             m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
             m.assert.equal(m.counterA, 1, "counterA must be incremented for each test case")
-            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in afterEach")
         end sub)
 
         m.xit("skipped case", sub()
@@ -39,7 +37,6 @@ function main(args as object) as object
             m.inScopeValue = "in-scope"
             m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
             m.assert.equal(m.counterA, 2, "counterA must be incremented for each test case")
-            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in afterEach")
         end sub)
     end sub)
 end function

--- a/test/before-after/after-each/tests/02-single-level.test.brs
+++ b/test/before-after/after-each/tests/02-single-level.test.brs
@@ -1,0 +1,45 @@
+function main(args as object) as object
+    return roca(args).describe("single-level root", sub()
+        m.addContext({
+            counterA: 0
+        })
+
+        m.afterEach(sub()
+            ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+            ' and are being done here as part of testing the test framework; please don't view this as
+            ' tacit approval to do the same in production tests :)
+            if m.__suite.__ctx.counterA <> invalid then m.__suite.__ctx.counterA++
+            m.append(m.__suite.__ctx)
+
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value from each test")
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.isInvalid(m.inScopeValue, "inScopeValue must not spread to sibling tests")
+            m.inScopeValue = "in-scope"
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 0, "counterA must be incremented for each test case")
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in afterEach")
+        end sub)
+
+        m.it("case 2", sub()
+            m.assert.isInvalid(m.inScopeValue, "inScopeValue must not spread to sibling tests")
+            m.inScopeValue = "in-scope"
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 1, "counterA must be incremented for each test case")
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in afterEach")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; afterEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.isInvalid(m.inScopeValue, "inScopeValue must not spread to sibling tests")
+            m.inScopeValue = "in-scope"
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 2, "counterA must be incremented for each test case")
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in afterEach")
+        end sub)
+    end sub)
+end function

--- a/test/before-after/after-each/tests/03-multiple-calls.test.brs
+++ b/test/before-after/after-each/tests/03-multiple-calls.test.brs
@@ -1,0 +1,53 @@
+function main(args as object) as object
+    return roca(args).describe("multiple-calls root", sub()
+        m.addContext({
+            counterA: 0,
+            incrementCounterA: incrementCounterA
+        })
+
+        m.afterEach(sub()
+            m.incrementCounterA()
+            m.inScopeValue = "in-scope"
+        end sub)
+
+        m.afterEach(sub()
+            m.incrementCounterA()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope in subsequent afterEach calls")
+        end sub)
+
+        m.afterEach(sub()
+            m.incrementCounterA()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope in subsequent afterEach calls")
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.isInvalid(m.inScopeValue, "inScopeValue must not persist in between tests")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 0, "counterA must be incremented for each test case")
+        end sub)
+
+        m.it("case 2", sub()
+            m.assert.isInvalid(m.inScopeValue, "inScopeValue must not persist in between tests")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 3, "counterA must be incremented for each test case")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; afterEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.isInvalid(m.inScopeValue, "inScopeValue must not persist in between tests")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 6, "counterA must be incremented for each test case")
+        end sub)
+    end sub)
+end function
+
+sub incrementCounterA()
+    ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+    ' and are being done here as part of testing the test framework; please don't view this as
+    ' tacit approval to do the same in production tests :)
+    if m.__suite.__ctx.counterA <> invalid then m.__suite.__ctx.counterA++
+    m.append(m.__suite.__ctx)
+end sub

--- a/test/before-after/before-after.test.js
+++ b/test/before-after/before-after.test.js
@@ -1,0 +1,28 @@
+
+const { rocaInDir } = require("../util");
+
+describe("before-after", () => {
+    test("single-level", async () => {
+        let results = await rocaInDir(__dirname, "before-each");
+
+        expect(results.stats).toMatchObject({
+            suites: 3,
+            tests: 3,
+            passes: 1,
+            pending: 1,
+            failures: 0
+        });
+
+        expect(results.passes).toMatchObject([
+            { fullTitle: "nested root suite 1 case 1.1" },
+            { fullTitle: "nested root suite 1 case 1.2" },
+            { fullTitle: "nested root suite 1 case 1.3" },
+            { fullTitle: "nested root case 1" },
+            { fullTitle: "nested root case 2" },
+            { fullTitle: "nested root case 3" },
+            { fullTitle: "single-level root case 1" },
+            { fullTitle: "single-level root case 2" },
+            { fullTitle: "single-level root case 3" },
+        ]);
+    });
+});

--- a/test/before-after/before-after.test.js
+++ b/test/before-after/before-after.test.js
@@ -2,8 +2,33 @@
 const { rocaInDir } = require("../util");
 
 describe("before-after", () => {
-    test("single-level", async () => {
+    test("before-each", async () => {
         let results = await rocaInDir(__dirname, "before-each");
+
+        expect(results.stats).toMatchObject({
+            suites: 4,
+            tests: 12,
+            passes: 9,
+            pending: 3,
+            failures: 0
+        });
+
+        expect(results.passes).toMatchObject([
+            { fullTitle: "nested root suite 1 case 1.1" },
+            { fullTitle: "nested root suite 1 case 1.2" },
+            { fullTitle: "nested root suite 1 case 1.3" },
+            { fullTitle: "nested root case 1" },
+            { fullTitle: "nested root case 2" },
+            { fullTitle: "nested root case 3" },
+            { fullTitle: "single-level root case 1" },
+            { fullTitle: "single-level root case 2" },
+            { fullTitle: "single-level root case 3" },
+        ]);
+    });
+
+    test("after-each", async () => {
+        let results = await rocaInDir(__dirname, "after-each");
+        console.log(results.failures)
 
         expect(results.stats).toMatchObject({
             suites: 4,

--- a/test/before-after/before-after.test.js
+++ b/test/before-after/before-after.test.js
@@ -6,10 +6,10 @@ describe("before-after", () => {
         let results = await rocaInDir(__dirname, "before-each");
 
         expect(results.stats).toMatchObject({
-            suites: 3,
-            tests: 3,
-            passes: 1,
-            pending: 1,
+            suites: 4,
+            tests: 12,
+            passes: 9,
+            pending: 3,
             failures: 0
         });
 

--- a/test/before-after/before-after.test.js
+++ b/test/before-after/before-after.test.js
@@ -6,10 +6,10 @@ describe("before-after", () => {
         let results = await rocaInDir(__dirname, "before-each");
 
         expect(results.stats).toMatchObject({
-            suites: 4,
-            tests: 12,
-            passes: 9,
-            pending: 3,
+            suites: 5,
+            tests: 16,
+            passes: 12,
+            pending: 4,
             failures: 0
         });
 
@@ -23,12 +23,41 @@ describe("before-after", () => {
             { fullTitle: "single-level root case 1" },
             { fullTitle: "single-level root case 2" },
             { fullTitle: "single-level root case 3" },
+            { fullTitle: "multiple-calls root case 1" },
+            { fullTitle: "multiple-calls root case 2" },
+            { fullTitle: "multiple-calls root case 3" },
         ]);
     });
 
     test("after-each", async () => {
         let results = await rocaInDir(__dirname, "after-each");
-        console.log(results.failures)
+
+        expect(results.stats).toMatchObject({
+            suites: 5,
+            tests: 16,
+            passes: 12,
+            pending: 4,
+            failures: 0
+        });
+
+        expect(results.passes).toMatchObject([
+            { fullTitle: "nested root suite 1 case 1.1" },
+            { fullTitle: "nested root suite 1 case 1.2" },
+            { fullTitle: "nested root suite 1 case 1.3" },
+            { fullTitle: "nested root case 1" },
+            { fullTitle: "nested root case 2" },
+            { fullTitle: "nested root case 3" },
+            { fullTitle: "single-level root case 1" },
+            { fullTitle: "single-level root case 2" },
+            { fullTitle: "single-level root case 3" },
+            { fullTitle: "multiple-calls root case 1" },
+            { fullTitle: "multiple-calls root case 2" },
+            { fullTitle: "multiple-calls root case 3" },
+        ]);
+    });
+
+    test("mixed", async () => {
+        let results = await rocaInDir(__dirname, "mixed");
 
         expect(results.stats).toMatchObject({
             suites: 4,

--- a/test/before-after/before-each/tests/01-nested.test.brs
+++ b/test/before-after/before-each/tests/01-nested.test.brs
@@ -1,0 +1,69 @@
+function main(args as object) as object
+    return roca(args).describe("nested root", sub()
+        m.addContext({
+            counterB: 0
+        })
+
+        m.beforeEach(sub()
+            ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+            ' and are being done here as part of testing the test framework; please don't view this as
+            ' tacit approval to do the same in production tests :)
+            if m.__suite.__ctx.counterB <> invalid then m.__suite.__ctx.counterB++
+            m.append(m.__suite.__ctx)
+            print "parent beforeEach"
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 4, "counterC must be incremented for each test case")
+        end sub)
+
+        m.it("case 2", sub()
+        print m
+            m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 5, "counterC must be incremented for each test case")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; beforeEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 6, "counterC must be incremented for each test case")
+        end sub)
+
+        m.describe("suite 1", sub()
+            m.addContext({
+                counterC: 0
+            })
+
+            m.beforeEach(sub()
+                ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+                ' and are being done here as part of testing the test framework; please don't view this as
+                ' tacit approval to do the same in production tests :)
+                if m.__suite.__ctx.counterC <> invalid then m.__suite.__ctx.counterC++
+                m.append(m.__suite.__ctx)
+            end sub)
+
+            m.it("case 1.1", sub()
+                m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 1, "counterC must be incremented for each test case")
+            end sub)
+
+            m.it("case 1.2", sub()
+                m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 2, "counterC must be incremented for each test case")
+            end sub)
+
+            m.xit("skipped case", sub()
+                ' intentionally empty; beforeEach() function shouldn't be called for this case
+            end sub)
+
+            m.it("case 1.3", sub()
+                m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 3, "counterC must be incremented for each test case")
+            end sub)
+        end sub)
+    end sub)
+end function

--- a/test/before-after/before-each/tests/01-nested.test.brs
+++ b/test/before-after/before-each/tests/01-nested.test.brs
@@ -10,18 +10,16 @@ function main(args as object) as object
             ' tacit approval to do the same in production tests :)
             if m.__suite.__ctx.counterB <> invalid then m.__suite.__ctx.counterB++
             m.append(m.__suite.__ctx)
-            print "parent beforeEach"
         end sub)
 
         m.it("case 1", sub()
             m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
-            m.assert.equal(m.counterB, 4, "counterC must be incremented for each test case")
+            m.assert.equal(m.counterB, 4, "counterB must be incremented for each test case")
         end sub)
 
         m.it("case 2", sub()
-        print m
             m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
-            m.assert.equal(m.counterB, 5, "counterC must be incremented for each test case")
+            m.assert.equal(m.counterB, 5, "counterB must be incremented for each test case")
         end sub)
 
         m.xit("skipped case", sub()
@@ -30,7 +28,7 @@ function main(args as object) as object
 
         m.it("case 3", sub()
             m.assert.isInvalid(m.counterA, "beforeEach state must not spread to sibling suites")
-            m.assert.equal(m.counterB, 6, "counterC must be incremented for each test case")
+            m.assert.equal(m.counterB, 6, "counterB must be incremented for each test case")
         end sub)
 
         m.describe("suite 1", sub()

--- a/test/before-after/before-each/tests/02-single-level.test.brs
+++ b/test/before-after/before-each/tests/02-single-level.test.brs
@@ -10,16 +10,20 @@ function main(args as object) as object
             ' tacit approval to do the same in production tests :)
             if m.__suite.__ctx.counterA <> invalid then m.__suite.__ctx.counterA++
             m.append(m.__suite.__ctx)
+
+            m.inScopeValue = "in-scope"
         end sub)
 
         m.it("case 1", sub()
             m.assert.isInvalid(m.counterB, "beforeEach state must not spread to sibling suites")
             m.assert.equal(m.counterA, 1, "counterA must be incremented for each test case")
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in beforeEach")
         end sub)
 
         m.it("case 2", sub()
             m.assert.isInvalid(m.counterB, "beforeEach state must not spread to sibling suites")
             m.assert.equal(m.counterA, 2, "counterA must be incremented for each test case")
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in beforeEach")
         end sub)
 
         m.xit("skipped case", sub()
@@ -29,6 +33,7 @@ function main(args as object) as object
         m.it("case 3", sub()
             m.assert.isInvalid(m.counterB, "beforeEach state must not spread to sibling suites")
             m.assert.equal(m.counterA, 3, "counterA must be incremented for each test case")
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must match its set value in beforeEach")
         end sub)
     end sub)
 end function

--- a/test/before-after/before-each/tests/02-single-level.test.brs
+++ b/test/before-after/before-each/tests/02-single-level.test.brs
@@ -1,0 +1,34 @@
+function main(args as object) as object
+    return roca(args).describe("single-level root", sub()
+        m.addContext({
+            counterA: 0
+        })
+
+        m.beforeEach(sub()
+            ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+            ' and are being done here as part of testing the test framework; please don't view this as
+            ' tacit approval to do the same in production tests :)
+            if m.__suite.__ctx.counterA <> invalid then m.__suite.__ctx.counterA++
+            m.append(m.__suite.__ctx)
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.isInvalid(m.counterB, "beforeEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 1, "counterA must be incremented for each test case")
+        end sub)
+
+        m.it("case 2", sub()
+            m.assert.isInvalid(m.counterB, "beforeEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 2, "counterA must be incremented for each test case")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; beforeEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.isInvalid(m.counterB, "beforeEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 3, "counterA must be incremented for each test case")
+        end sub)
+    end sub)
+end function

--- a/test/before-after/before-each/tests/03-multiple-calls.test.brs
+++ b/test/before-after/before-each/tests/03-multiple-calls.test.brs
@@ -1,0 +1,53 @@
+function main(args as object) as object
+    return roca(args).describe("multiple-calls root", sub()
+        m.addContext({
+            counterA: 0,
+            incrementCounterA: incrementCounterA
+        })
+
+        m.beforeEach(sub()
+            m.incrementCounterA()
+            m.inScopeValue = "in-scope"
+        end sub)
+
+        m.beforeEach(sub()
+            m.incrementCounterA()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope in subsequent beforeEach calls")
+        end sub)
+
+        m.beforeEach(sub()
+            m.incrementCounterA()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope in subsequent beforeEach calls")
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope from beforeEach")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 3, "counterA must be incremented for each test case")
+        end sub)
+
+        m.it("case 2", sub()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope from beforeEach")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 6, "counterA must be incremented for each test case")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; afterEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope from beforeEach")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 9, "counterA must be incremented for each test case")
+        end sub)
+    end sub)
+end function
+
+sub incrementCounterA()
+    ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+    ' and are being done here as part of testing the test framework; please don't view this as
+    ' tacit approval to do the same in production tests :)
+    if m.__suite.__ctx.counterA <> invalid then m.__suite.__ctx.counterA++
+    m.append(m.__suite.__ctx)
+end sub

--- a/test/before-after/mixed/tests/01-nested.test.brs
+++ b/test/before-after/mixed/tests/01-nested.test.brs
@@ -1,0 +1,85 @@
+function main(args as object) as object
+    return roca(args).describe("nested root", sub()
+        m.addContext({
+            counterB: 0,
+            incrementCounterB: incrementCounterB
+        })
+
+        m.beforeEach(sub()
+            m.incrementCounterB()
+        end sub)
+
+        m.afterEach(sub()
+            m.incrementCounterB()
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 7, "counterB must be incremented for each test case")
+        end sub)
+
+        m.it("case 2", sub()
+            m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 9, "counterB must be incremented for each test case")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; afterEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterB, 11, "counterB must be incremented for each test case")
+        end sub)
+
+        m.describe("suite 1", sub()
+            m.addContext({
+                counterC: 0,
+                incrementCounterC: incrementCounterC
+            })
+
+            m.beforeEach(sub()
+                m.incrementCounterC()
+            end sub)
+
+            m.afterEach(sub()
+                m.incrementCounterC()
+            end sub)
+
+            m.it("case 1.1", sub()
+                m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 1, "counterC must be incremented for each test case")
+            end sub)
+
+            m.it("case 1.2", sub()
+                m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 3, "counterC must be incremented for each test case")
+            end sub)
+
+            m.xit("skipped case", sub()
+                ' intentionally empty; afterEach() function shouldn't be called for this case
+            end sub)
+
+            m.it("case 1.3", sub()
+                m.assert.isInvalid(m.counterA, "afterEach state must not spread to sibling suites")
+                m.assert.equal(m.counterC, 5, "counterC must be incremented for each test case")
+            end sub)
+        end sub)
+    end sub)
+end function
+
+sub incrementCounterB()
+    ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+    ' and are being done here as part of testing the test framework; please don't view this as
+    ' tacit approval to do the same in production tests :)
+    if m.__suite.__ctx.counterB <> invalid then m.__suite.__ctx.counterB++
+    m.append(m.__suite.__ctx)
+end sub
+
+sub incrementCounterC()
+    ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+    ' and are being done here as part of testing the test framework; please don't view this as
+    ' tacit approval to do the same in production tests :)
+    if m.__suite.__ctx.counterC <> invalid then m.__suite.__ctx.counterC++
+    m.append(m.__suite.__ctx)
+end sub

--- a/test/before-after/mixed/tests/02-single-level.test.brs
+++ b/test/before-after/mixed/tests/02-single-level.test.brs
@@ -1,0 +1,50 @@
+function main(args as object) as object
+    return roca(args).describe("single-level root", sub()
+        m.addContext({
+            counterA: 0,
+            incrementCounterA: incrementCounterA
+        })
+
+        m.beforeEach(sub()
+            m.incrementCounterA()
+
+            m.inScopeValue = "in-scope"
+        end sub)
+
+        m.afterEach(sub()
+            m.incrementCounterA()
+
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope in the afterEach")
+        end sub)
+
+        m.it("case 1", sub()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope from beforeEach")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 1, "counterA must be incremented for each test case")
+        end sub)
+
+        m.it("case 2", sub()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope from beforeEach")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 3, "counterA must be incremented for each test case")
+        end sub)
+
+        m.xit("skipped case", sub()
+            ' intentionally empty; afterEach() function shouldn't be called for this case
+        end sub)
+
+        m.it("case 3", sub()
+            m.assert.equal(m.inScopeValue, "in-scope", "inScopeValue must remain in scope from beforeEach")
+            m.assert.isInvalid(m.counterB, "afterEach state must not spread to sibling suites")
+            m.assert.equal(m.counterA, 5, "counterA must be incremented for each test case")
+        end sub)
+    end sub)
+end function
+
+sub incrementCounterA()
+    ' WARNING: accessing m.__suite and m.__suite.__ctx are prone to breakage in future releases,
+    ' and are being done here as part of testing the test framework; please don't view this as
+    ' tacit approval to do the same in production tests :)
+    if m.__suite.__ctx.counterA <> invalid then m.__suite.__ctx.counterA++
+    m.append(m.__suite.__ctx)
+end sub


### PR DESCRIPTION
# Change Summary

Our current implementation of `beforeEach`/`afterEach` didn't propagate calls to nested suites, so a parent suite's `beforeEach` wasn't running before a child suite's tests. This PR fixes it (and adds integration tests).