### PR TITLE
fix(error-handling): roca main always returns an assoc array

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ const argv = require('yargs')
     })
     .command(
         ["$0", "run "],
-        "Discovers and executes all .test.brs tests in the current directory", 
+        "Discovers and executes all .test.brs tests in the current directory",
         (yargs) => {
             yargs.option("reporter", {
                 // use capital-R for reporter selection to match mocha
@@ -51,7 +51,7 @@ const argv = require('yargs')
     .describe("r", "Path to a required setup file (will be run before unit tests)")
     .alias("r", "require")
     .describe("f", "Fail if focused test or suite is encountered")
-    .alias("f", "--forbid-focused")
+    .alias("f", "forbid-focused")
     .help("h")
     .alias("h", "help")
     .argv;

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -1,4 +1,4 @@
-function main() as dynamic
+function main() as object
     files = []
     dirsToSearch = ["test", "tests", "source", "components"]
     for each dir in dirsToSearch

--- a/resources/roca_main.brs
+++ b/resources/roca_main.brs
@@ -1,4 +1,4 @@
-function main() as object
+function main() as dynamic
     files = []
     dirsToSearch = ["test", "tests", "source", "components"]
     for each dir in dirsToSearch
@@ -15,7 +15,7 @@ function main() as object
 
         if suite = invalid then
             print "Error running tests: Runtime exception occurred in " + filePathWithoutPkg
-            return
+            return {}
         end if
 
         if GetInterface(suite, "ifArray") = invalid then
@@ -60,7 +60,7 @@ function main() as object
         ' If brs returned invalid for runInScope, that means the suite threw an exception, so we should bail.
         if suite = invalid then
             tap.bail("Error running tests: Runtime exception occurred in " + filePath.replace("pkg:", ""))
-            return
+            return {}
         end if
 
         ' If there are focused cases, only update the index when we've run a focused root suite.


### PR DESCRIPTION
# Change Summary

While doing unit testing, I noticed that if a runtime exception occurred in my code, then roca would pile on with its own "mismatched return type" error.