### PR TITLE
fix(config): add src dir to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "src/index.js",
   "files": [
     "bin/",
-    "resources/"
+    "resources/",
+    "src"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
# Change Summary

This adds the `src` dir to the list of files. `src/coverage.js` wasn't getting bundled along with the rest of the files, which causes `roca` to break.