### PR TITLE
fix(infra): Rename default branch from `master` to `main`

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,10 +2,10 @@
   name: "PR & Push",
   on: {
     push: {
-      branches: [ "master" ]
+      branches: [ "main" ]
     },
     pull_request: {
-      branches: [ "master" ]
+      branches: [ "main" ]
     }
   },
   jobs: {


### PR DESCRIPTION
Remove hurtful language by following the example of git [1] and GitHub [2], i.e. rename `master` to `main`.

[1] https://lore.kernel.org/git/pull.783.git.1604829561838.gitgitgadget@gmail.com/
[2] https://github.com/github/renaming