### PR TITLE
Fix wrong comparison for __roca_deepEquals

### DIFF
--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -74,6 +74,8 @@ end sub
 function __roca_deepEquals(lhs as object, rhs as object) as boolean
     isEqual = true
 
+    if type(lhs) <> type(rhs) then return false
+
     if __roca_isArray(lhs) and __roca_isArray(rhs) then
         ' base case
         if lhs.count() <> rhs.count() then return false


### PR DESCRIPTION
This PR fixes issue #63 __roca_deepEquals compare objects with different types as equal