### PR TITLE
fix(infra): add a prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "tsc",
     "clean": "rimraf ./lib ./types",
     "lint": "tslint --project .",
+    "prepublishOnly": "npm-run-all --serial clean build lint prettier test",
     "prettier": "prettier --check \"{bin,src,test}/**/*.{js,ts}\"",
     "prettier:write": "prettier --write \"{bin,src,test}/**/*.{js,ts}\"",
     "test": "jest",


### PR DESCRIPTION
# Change Summary

This adds `prepublishOnly` so that our package gets built before it gets published.