### PR TITLE
fix(assert) check if both are numeric instead of comparing

### DIFF
--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -142,7 +142,7 @@ function __roca_deepEquals(lhs as object, rhs as object) as boolean
         end for
     end if
 
-    if __roca_isNumeric(lhs) <> __roca_isNumeric(rhs) then
+    if __roca_isNumeric(lhs) and __roca_isNumeric(rhs) then
         if lhs <> rhs then return false
     end if
 


### PR DESCRIPTION
# Context
It's causing numeric comparison unreliable in deepEquals.