### PR TITLE
fix(assert): convert values to string for better output diffs

### DIFF
--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -84,6 +84,15 @@ function __formatError(error)
     numStackFrames = 3
     stackFrames = _brs_.getStackTrace(numStackFrames, fileFilters)
 
+    ' Convert to strings so we can see diffs
+    if GetInterface(error.expected, "ifString") = invalid then
+        error.expected = formatJson(error.expected)
+    end if
+
+    if GetInterface(error.actual, "ifString") = invalid then
+        error.actual = formatJson(error.actual)
+    end if
+
     ' Format this into the object that tap-mocha-reporter expects
     return {
         error: {
@@ -102,7 +111,9 @@ sub __deepEquals(actual, expected, error)
     else
         m.__fail(m.formatError({
             message: error,
-            funcName: "m.deepEquals"
+            funcName: "m.deepEquals",
+            expected: expected,
+            actual: actual
         }))
     end if
 end sub


### PR DESCRIPTION
# Change summary

This converts all expected/actual values to strings so that we always get a diff in the output for failed tests. This is especially nice for `deepEquals`, where this:
```brs
m.assert.deepEquals( { foo: ["bar"] }, { foo: ["baz"] }, "expected deep equal")
```
results in:
![Screen Shot 2021-02-03 at 2 26 20 PM](https://user-images.githubusercontent.com/11684087/106817628-fd0c4a00-662b-11eb-90d3-60b853e715c5.png)
