### PR TITLE
fix(reporter): Use multiline strings to escape YAML

### DIFF
--- a/resources/tap.brs
+++ b/resources/tap.brs
@@ -95,9 +95,16 @@ sub __tap_printExtras(extra = {}, level = 0)
     m.indent()
     for each item in extra
         if type(extra[item]) = "roAssociativeArray" then
-            print m.getIndent() item ":"
             level = level + 1
-            m.printExtras(extra[item], level)
+            if extra[item]._roca_isMultilineString = true
+                print m.getIndent() item ": >-"
+                m.indent()
+                print m.getIndent() extra[item].value
+                m.deindent()
+            else
+                print m.getIndent() item ":"
+                m.printExtras(extra[item], level)
+            end if
             level = level - 1
         else if type(extra[item]) = "roArray" then
             print m.getIndent() item ":"

--- a/resources/tap/main.brs
+++ b/resources/tap/main.brs
@@ -1,0 +1,7 @@
+' Initializes a tap instance and prints out the plan.
+function main(numSuites)
+    tapInstance = tap()
+    tapInstance.version()
+    tapInstance.plan(numSuites)
+    return tapInstance
+end function

--- a/resources/tap/tap.brs
+++ b/resources/tap/tap.brs
@@ -2,13 +2,6 @@
 ' intended to be consumed by any known TAP stream consumer for further prettification.
 '
 ' Adapted in part from https://github.com/mochajs/mocha/blob/5f8df0848aa52bb0f7a0844bcd3715012a6ecfd6/lib/reporters/tap.js
-function main(numSuites)
-    tapInstance = tap()
-    tapInstance.version()
-    tapInstance.plan(numSuites)
-    return tapInstance
-end function
-
 function Tap() as object
     return {
         version: __tap_version,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,9 +40,11 @@ async function run(files: string[], options: Options) {
 
     // Get the list of files that we should load into the execution scope.
     // Loading them here ensures that they only get lexed/parsed once.
-    let inScopeFiles = ["roca_lib.brs", "assert_lib.brs"].map((basename) =>
-        path.join(__dirname, "..", "resources", basename)
-    );
+    let inScopeFiles = [
+        "roca_lib.brs",
+        "assert_lib.brs",
+        path.join("tap", "tap.brs"),
+    ].map((basename) => path.join(__dirname, "..", "resources", basename));
     if (requireFilePath) {
         inScopeFiles.push(requireFilePath);
     }

--- a/src/runner/TestRunner.ts
+++ b/src/runner/TestRunner.ts
@@ -18,7 +18,7 @@ export class TestRunner {
     ) {
         // Create an instance of the BrightScript TAP object so we can pass it to the tests for reporting.
         let tap = execute(
-            [path.join(__dirname, "..", "..", "resources", "tap.brs")],
+            [path.join(__dirname, "..", "..", "resources", "tap", "main.brs")],
             [new BrsTypes.Int32(testFiles.length)]
         );
         let executeArgs = this.generateExecuteArgs(tap, focusedCasesDetected);


### PR DESCRIPTION
# Summary

Closes #72. This converts all of our expected/actual values to be YAML multiline strings, which has the effect of escaping any YAML special characters that may appear in strings/variable names.

Also, converting everything to a string ensures that `tap-mocha-reporter` always shows an error diff -- it does not print _any_ diff output if the types of expected vs. actual are not the same.

This also fixes a bug where `roca.log("message")` was not working due to a reference error.

![Screen Shot 2021-03-05 at 1 32 23 PM](https://user-images.githubusercontent.com/11684087/110175836-3ebd1b80-7db7-11eb-8e25-2b931ad4e4b3.png)


![Screen Shot 2021-03-05 at 1 31 08 PM](https://user-images.githubusercontent.com/11684087/110175702-103f4080-7db7-11eb-8393-8ff28df95e27.png)

