### PR TITLE
feat(docs): add function testing guide

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -11,5 +11,6 @@
     * [FAQs](resources/faq.md)
 
 * Guides
+    * [About](guides/)
     * [Setting up and cleaning up tests](guides/test-setup.md)
-    * [Testing private functions](faq/testing-private-functions.md)
+    * [Testing functions](guides/testing-functions.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,3 +1,3 @@
 # Guides
 
-We've created few guides that are intended to answer common questions or demonstrate testing strategies in more detail. If there are guides that you would like to see in the future, check out [the `roca` project open issues](https://github.com/hulu/roca/issues) to see if it's already being tracked, and create a new issue if needed.
+We've created several guides that are intended to answer common questions or demonstrate testing strategies in more detail. If there are guides that you would like to see in the future, check out [the `roca` project open issues](https://github.com/hulu/roca/issues) to see if it's already being tracked, and create a new issue if needed.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,3 @@
+# Guides
+
+We've created few guides that are intended to answer common questions or demonstrate testing strategies in more detail. If there are guides that you would like to see in the future, check out [the `roca` project open issues](https://github.com/hulu/roca/issues) to see if it's already being tracked, and create a new issue if needed.

--- a/docs/guides/testing-functions.md
+++ b/docs/guides/testing-functions.md
@@ -35,7 +35,8 @@ The best way to test `.brs` files in the `components/` tree is to write componen
 For example, if we have this file: `<project root>/components/foo-workflow/foo.brs`
 ```brightscript
 function foo()
-    return "foo"
+    m.top.sideEffectField = "foo"
+    return m.top.sideEffectField
 end function
 ```
 
@@ -49,7 +50,11 @@ If `FooComponent` uses the `foo` function as a callback:
 <component name="FooComponent">
     <script type="text/brightscript" uri="pkg:/components/foo-workflow/foo.brs" />
     <interface>
+        <!-- Field with a callback we want to test -->
         <field id="myField" type="string" onChange="foo" />
+
+        <!-- Field with a callback we want to test -->
+        <field id="sideEffectField" type="string">
     </interface>
 </component>
 ```
@@ -68,6 +73,9 @@ m.it("calls foo when myField is modified", sub()
 
     ' assert that it was called
     m.assert.equal(spy.calls.count(), 1, "expected foo to be called once")
+
+    ' assert on the side effect
+    m.assert.equal(component.sideEffectField, "foo", "expected sideEffectField value to be 'foo'")
 end sub)
 ```
 
@@ -98,6 +106,9 @@ m.it("calls foo", sub()
 
     ' assert that it was called
     m.assert.equal(spy.calls.count(), 1, "expected foo to be called once")
+
+    ' assert on the side effect
+    m.assert.equal(component.sideEffectField, "foo", "expected sideEffectField value to be 'foo'")
 end sub)
 ```
 
@@ -114,7 +125,8 @@ The easiest way to test private functions (functions that are not exposed in the
 For example, if we have this file: `<project root>/components/foo-workflow/foo.brs`
 ```brightscript
 function foo()
-    return "foo"
+    m.top.sideEffectField = "foo"
+    return m.top.sideEffectField
 end function
 ```
 
@@ -143,6 +155,9 @@ m.it("calls foo", sub()
 
     ' assert that it was called
     m.assert.equal(spy.calls.count(), 1, "expected foo to be called once")
+
+    ' assert on the side effect
+    m.assert.equal(component.sideEffectField, "foo", "expected sideEffectField value to be 'foo'")
 end sub)
 ```
 

--- a/docs/guides/testing-functions.md
+++ b/docs/guides/testing-functions.md
@@ -1,0 +1,173 @@
+# Testing functions
+
+# Functions in the `source/` directory tree
+
+To make testing functions easier, any function that appears in the `source/` directory is put into the global scope. This means that you can directly call these functions from your test case. For example:
+
+Source file: `<project root>/source/utilities/myUtil.brs`
+```brightscript
+function myUtil()
+    return "awesome!"
+end function
+```
+
+Test file:
+```brightscript
+m.describe("myUtil.brs", sub()
+    m.it("returns something awesome", sub()
+        ' We can directly call myUtil, because it's in scope
+        output = myUtil()
+        m.assert.equal(output, "awesome!", "output failed to match")
+    end sub)
+end sub)
+```
+
+# Functions in the `components/` directory tree
+
+Component scope is a bit more complicated, so we don't put files in the `components/` directory tree into the global scope. Because of this, any `.brs` files that are in `components/` will need to be tested by pulling the file in using a `<script>` tag in a component.
+
+There are a couple ways to accomplish this:
+
+## Use a source component
+
+The best way to test `.brs` files in the `components/` tree is to write component-level tests for whichever component(s) consume the `.brs` file in your application. This is good practice because your tests will align more closely to how the code is being used in your actual application.
+
+For example, if we have this file: `<project root>/components/foo-workflow/foo.brs`
+```brightscript
+function foo()
+    return "foo"
+end function
+```
+
+We can test the `foo` function based on how a component (which we'll call `FooComponent`) uses it:
+
+### As a callback
+
+If `FooComponent` uses the `foo` function as a callback:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="FooComponent">
+    <script type="text/brightscript" uri="pkg:/components/foo-workflow/foo.brs" />
+    <interface>
+        <field id="myField" type="string" onChange="foo" />
+    </interface>
+</component>
+```
+
+Then we can test it by modifying `myField` in our test case:
+```brightscript
+m.it("calls foo when myField is modified", sub()
+    ' create a spy
+    spy = _brs_.mockFunction("foo")
+
+    ' create the object
+    component = createObject("RoSGNode", "FooComponent")
+
+    ' modify the field to trigger the callback
+    component.myField = "something new"
+
+    ' assert that it was called
+    m.assert.equal(spy.calls.count(), 1, "expected foo to be called once")
+end sub)
+```
+
+### As a public function in the interface
+
+If `FooComponent` puts `foo` as a function in the interface:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="FooComponent">
+    <script type="text/brightscript" uri="pkg:/components/foo-workflow/foo.brs" />
+    <interface>
+        <function name="foo" />
+    </interface>
+</component>
+```
+
+Then we can test it using `callFunc`:
+```brightscript
+m.it("calls foo", sub()
+    ' create a spy
+    spy = _brs_.mockFunction("foo")
+
+    ' create the object
+    component = createObject("RoSGNode", "FooComponent")
+
+    ' call foo
+    component.callFunc("foo")
+
+    ' assert that it was called
+    m.assert.equal(spy.calls.count(), 1, "expected foo to be called once")
+end sub)
+```
+
+### As a private function
+
+If `foo` isn't defined as a callback or function in the component's `<interface>`, then `foo` is effectively a private function. In this case, you should consider the code paths that trigger `foo`, and the best way for your tests to exercise those code paths.
+
+If there is no straightforward way to trigger `foo` from a source component, then you can test it by creating a [test component](#use-a-test-component).
+
+## Use a test component
+
+The easiest way to test private functions (functions that are not exposed in the `<interface>` of a component) is by creating a "test component", or a component that only exists for unit tests. **Note: make sure that you are not bundling these as part of your application!**
+
+For example, if we have this file: `<project root>/components/foo-workflow/foo.brs`
+```brightscript
+function foo()
+    return "foo"
+end function
+```
+
+Then we can test it by creating a test component and exposing `foo` on the interface: `<project root>/tests/components/foo-workflow/Test_foo.brs`
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="Test_foo">
+    <script type="text/brightscript" uri="pkg:/components/foo-workflow/foo.brs" />
+    <interface>
+        <function name="foo" />
+    </interface>
+</component>
+```
+
+And in our test case, we can now create a `Test_foo` object and use `callFunc`:
+```brightscript
+m.it("calls foo", sub()
+    ' create a spy
+    spy = _brs_.mockFunction("foo")
+
+    ' create the object
+    component = createObject("RoSGNode", "FooComponent")
+
+    ' call foo
+    component.callFunc("foo")
+
+    ' assert that it was called
+    m.assert.equal(spy.calls.count(), 1, "expected foo to be called once")
+end sub)
+```
+
+### Reusing source component scope
+
+The above strategy works for most use cases. Sometimes, however, your `.brs` file relies on other `.brs` files, and it makes more sense to extend a source component. For example, consider this source component:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="FooComponent">
+    <script type="text/brightscript" uri="pkg:/components/foo-workflow/foo.brs" />
+    <script type="text/brightscript" uri="pkg:/components/foo-workflow/bar.brs" />
+    <script type="text/brightscript" uri="pkg:/components/other-workflow/baz.brs" />
+</component>
+```
+
+If `foo.brs` relies on `bar.brs` and `baz.brs`, it can get tedious to copy all the dependencies from `FooComponent` and put them into a test component, `Test_foo`. In this case, we can simply extend `FooComponent` and expose the necessary functions:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="Test_foo" extends="FooComponent">
+    <interface>
+        <function name="foo">
+    </interface>
+</component>
+```
+
+Now, we have the exact same scope as `FooComponent` in `Test_foo`, but we also have the benefit of the `foo` function being exposed in the public interface! :tada:

--- a/docs/guides/testing-private-functions.md
+++ b/docs/guides/testing-private-functions.md
@@ -1,3 +1,0 @@
-# Testing private functions
-
-TODO

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -3,6 +3,16 @@
 
 All code that lives in the `source/` directory is automatically pulled in-scope when you're executing code in any of the tests. So if you're testing functions from `source/`, then you can just call them directly from the test case.
 
+Check out our [Testing functions guide](guides/testing-functions.md) for more detailed information.
+
+<br />
+
+--------------
+
+## How do I test functions that are in the `components/` directory?
+
+Check out our [Testing functions guide](guides/testing-functions.md) for strategies to test `components/` functions.
+
 <br />
 
 --------------


### PR DESCRIPTION
# Summary

Closes #78 

To view the docs locally, run `npm run serve-docs`.