### PR TITLE
fix(reporter): don't double-count tests

### DIFF
--- a/src/reporter/JestReporter.ts
+++ b/src/reporter/JestReporter.ts
@@ -223,7 +223,6 @@ export class JestReporter {
      * @param status The test result status
      */
     protected addNonFailureTestResult(assert: Assert, status: Status) {
-        this.currentResults.numPassingTests++;
         this.currentResults.testResults.push(
             createAssertionResult(status, assert.name)
         );


### PR DESCRIPTION
# Summary

Whoops, our Jest reporter was double-counting all non-failure tests.