### PR TITLE
Issue #34 Add isValid assertion

### DIFF
--- a/docs/api/reference/asserts.md
+++ b/docs/api/reference/asserts.md
@@ -184,6 +184,32 @@ end sub)
 ------------
 
 
+## m.assert.isValid(value, errorMessage)
+Checks to see if a value is not `invalid`.
+
+### Parameters 
+**value** `dynamic` \
+The value that was calculated in your test case.
+------------
+**errorMessage** `string` \
+The error message to display if the value is invalid.
+------------
+
+### Return value 
+None.
+
+Usage:
+```brightscript
+m.it("test case", sub()
+    foo = {}
+    m.assert.isValid(foo, "whoops, foo should not be invalid")
+end sub)
+```
+<br/>
+
+------------
+
+
 ## m.assert.isInvalid(value, errorMessage)
 Checks to see if a value is `invalid`.
 

--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -7,6 +7,7 @@ function Assert(passFunc, failFunc, state) as object
         notEqual: __notEqual,
         isTrue: __isTrue,
         isFalse: __isFalse,
+        isValid: __isValid,
         isInvalid: __isInvalid,
         formatError: __formatError,
         deepEquals: __deepEquals
@@ -61,6 +62,19 @@ sub __isFalse(actual, error)
             actual: actual,
             expected: false,
             funcName: "m.assert.isFalse"
+        }))
+    end if
+end sub
+
+sub __isValid(actual, error)
+    if actual <> invalid then
+        m.__pass()
+    else
+        m.__fail(m.formatError({
+            message: error,
+            actual: actual,
+            expected: "non-invalid",
+            funcName: "m.assert.isValid"
         }))
     end if
 end sub


### PR DESCRIPTION
Resolves #34

Added new `isValid` assertion. Updated docs.

The only thing to note here is that there is no `expected` value because we're expecting anything except `invalid`. So I'm passing `non-invalid` string there.

Sample test case:
```
m.it("in the test case", sub()
    m.assert.isInvalid({}, "should be invalid")
    m.assert.isValid(invalid, "should be valid")
end sub)
```

When `isInvalid` not commented out:
![image](https://user-images.githubusercontent.com/35260686/114556613-8dd95480-9c71-11eb-8868-6845c68f2107.png)

When `isValid` not commented out:
![image](https://user-images.githubusercontent.com/35260686/114556625-903bae80-9c71-11eb-88c7-43d3b7876110.png)