### PR TITLE
fix(runner): return correct exit code when something fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ async function run(brsSourceFiles: string[], options: CliOptions) {
             )
         );
 
-        return {};
+        process.exit(1);
     }
 
     testRunner.run(execute, testFiles, focusedCasesDetected);

--- a/src/reporter/JestReporter.ts
+++ b/src/reporter/JestReporter.ts
@@ -242,5 +242,6 @@ export class JestReporter {
         this.currentResults.testResults.push(
             createAssertionResult("failed", assert.name, failureMessage)
         );
+        process.exitCode = 1;
     }
 }

--- a/src/runner/JestRunner.ts
+++ b/src/runner/JestRunner.ts
@@ -36,6 +36,7 @@ export class JestRunner extends TestRunner {
                 execute([filename], [executeArgs]);
             } catch (reason) {
                 this.reporter.onFileExecError(filename, index, reason);
+                process.exitCode = 1;
             }
             this.reporter.onFileComplete();
 


### PR DESCRIPTION
- Added correct exit code when test fails
- Added correct exit code when file fails execution
- Added correct exit code when `forbid-focused` option is passed and there is at least one focused test

fixes #94 