### PR TITLE
fix(reporter): don't use case sensitive keys

### DIFF
--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -111,7 +111,7 @@ function __formatError(error)
     ' Get the stack trace where the failed test is, filtering out any roca frames
     fileFilters = ["roca"]
     numStackFrames = 3
-    stackFrames = _brs_.getStackTrace(numStackFrames, fileFilters)
+    stack_frames = _brs_.getStackTrace(numStackFrames, fileFilters)
 
     error.expected = __asReadableValue(error.expected)
     error.actual = __asReadableValue(error.actual)
@@ -121,7 +121,8 @@ function __formatError(error)
         error: {
             name: error.funcName,
             message: error.message,
-            stackFrames: stackFrames
+            ' use snake case so we don't have to worry about case-sensitivity
+            stack_frames: stack_frames
         },
         wanted: error.expected,
         found: error.actual

--- a/resources/roca_lib.brs
+++ b/resources/roca_lib.brs
@@ -450,12 +450,13 @@ sub __util_fail(metadata = invalid)
     if m.__state.success <> false
         ' Supplement the metadata with error information
         if metadata = invalid
-            stackFrames = _brs_.getStackTrace(3, ["roca"])
+            stack_frames = _brs_.getStackTrace(3, ["roca"])
             metadata = {
                 error: {
                     message: "m.fail() was called",
                     name: "m.fail",
-                    stackFrames: stackFrames
+                    ' use snake case so we don't have to worry about case-sensitivity
+                    stack_frames: stack_frames
                 }
                 wanted: "pass",
                 found: "fail"
@@ -465,8 +466,8 @@ sub __util_fail(metadata = invalid)
         ' tap-mocha-reporter expects a string for the stack, so let's generate it
         metadata.error.stack = ""
         if metadata.error.name <> invalid then metadata.error.stack = metadata.error.name
-        if GetInterface(metadata.error.stackFrames, "ifArray") <> invalid and metadata.error.stackFrames.count() > 0 then
-            metadata.error.stack += " (" + metadata.error.stackFrames[0] + ")"
+        if GetInterface(metadata.error.stack_frames, "ifArray") <> invalid and metadata.error.stack_frames.count() > 0 then
+            metadata.error.stack += " (" + metadata.error.stack_frames[0] + ")"
         end if
 
         m.__state.success = false

--- a/src/reporter/utils.ts
+++ b/src/reporter/utils.ts
@@ -9,7 +9,7 @@ export interface Diag {
     error: {
         name: string;
         message: string;
-        stackframes: string[];
+        stack_frames: string[];
     };
     wanted: string;
     found: string;
@@ -65,7 +65,7 @@ export function createAssertionResult(
  */
 export function createFailureMessage(diag: Diag) {
     let {
-        error: { stackframes, message, name },
+        error: { stack_frames, message, name },
         wanted,
         found,
     } = diag;
@@ -84,7 +84,7 @@ export function createFailureMessage(diag: Diag) {
         /* expand */ false
     );
 
-    let formattedStackTrace = stackframes
+    let formattedStackTrace = stack_frames
         .map((line, index) => {
             if (index === 0 && name) {
                 return "at " + name + " (" + line + ")";

--- a/test/reporter/jest-reporter.test.ts
+++ b/test/reporter/jest-reporter.test.ts
@@ -205,7 +205,7 @@ describe("JestReporter.ts", () => {
                     error: {
                         name: "mock error name",
                         message: "mock message name",
-                        stackframes: ["mock:stack:frame"],
+                        stack_frames: ["mock:stack:frame"],
                     },
                     wanted: "foo",
                     found: "bar",


### PR DESCRIPTION
# Summary

`brs` [recently introduced](https://github.com/sjbarag/brs/commit/08baf5e3a78c058c756bc12c1b50d60ad9886dce) better handling of associative array keys, and case-sensitive keys are now the default when printing assoc arrays. However, this broke our `stackFrames` implementation because we used camel case. This results in a runtime error that prints out a **Javascript** stack trace to the user whenever they have a failed test case.

An easy, backwards-compatible fix is to use snake case instead!