### PR TITLE
[#110] - support fast-glob for windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,9 @@ interface CliOptions {
 
 async function findBrsFiles(sourceDir?: string) {
     let searchDir = sourceDir || "source";
-    const pattern = path.join(process.cwd(), searchDir, "**", "*.brs");
+    const pattern = path
+        .join(process.cwd(), searchDir, "**", "*.brs")
+        .replace(/\\/g, "/");
     return fastGlob(pattern);
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,7 +47,7 @@ export async function globMatchFiles(filePatterns: string[]) {
     } else {
         testsPattern += `{${parsedPatterns.join(",")}}`;
     }
-
+    testsPattern = testsPattern.replace(/\\/g, "/");
     // exclude node_modules from the test search
     return fastGlob([testsPattern, `!${process.cwd()}/node_modules/**/*`]);
 }


### PR DESCRIPTION
migration from glob to fast-glob in release v22 broke windows compatibility,
fast-glob supporting forward-slashes only