### PR TITLE
HULUROKU-6968 - update to rokucommunity/brs version 0.47.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/long": "^4.0.1",
     "@types/memory-fs": "^0.3.2",
     "@types/xmldoc": "^1.1.5",
-    "@rokucommunity/brs": "^0.45.0",
+    "brs": "^0.45.0",
     "docsify-cli": "^4.4.2",
     "doctoc": "^1.4.0",
     "husky": "^4.2.5",
@@ -73,7 +73,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "@rokucommunity/brs": "^0.45.0"
+    "brs": "^0.45.0"
   },
   "lint-staged": {
     "./README.md": "doctoc",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/long": "^4.0.1",
     "@types/memory-fs": "^0.3.2",
     "@types/xmldoc": "^1.1.5",
-    "brs": "^0.45.0",
+    "@rokucommunity/brs": "^0.45.0",
     "docsify-cli": "^4.4.2",
     "doctoc": "^1.4.0",
     "husky": "^4.2.5",
@@ -73,7 +73,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "brs": "^0.45.0"
+    "@rokucommunity/brs": "^0.45.0"
   },
   "lint-staged": {
     "./README.md": "doctoc",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/long": "^4.0.1",
     "@types/memory-fs": "^0.3.2",
     "@types/xmldoc": "^1.1.5",
-    "brs": "^0.43.0",
+    "@rokucommunity/brs": "^0.45.0",
     "docsify-cli": "^4.4.2",
     "doctoc": "^1.4.0",
     "husky": "^4.2.5",
@@ -73,7 +73,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "brs": "^0.43.0"
+    "@rokucommunity/brs": "^0.45.0"
   },
   "lint-staged": {
     "./README.md": "doctoc",

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -1,7 +1,7 @@
 import { createContext } from "istanbul-lib-report";
 import { create as createReport, ReportOptions } from "istanbul-reports";
 import { createCoverageMap } from "istanbul-lib-coverage";
-import { getCoverageResults } from "brs";
+import { getCoverageResults } from "@rokucommunity/brs";
 
 /*
  * Generates coverage reports using the given list of reporters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import { types, ExecuteWithScope, createExecuteWithScope } from "brs";
+import {
+    types,
+    ExecuteWithScope,
+    createExecuteWithScope,
+} from "@rokucommunity/brs";
 import fastGlob from "fast-glob";
 import * as path from "path";
 import * as c from "ansi-colors";

--- a/src/reporter/JestReporter.ts
+++ b/src/reporter/JestReporter.ts
@@ -21,7 +21,7 @@ import {
     createFailureMessage,
 } from "./utils";
 import type { Config } from "@jest/types";
-import { BrsError } from "brs/types/Error";
+import { BrsError } from "@rokucommunity/brs/types/Error";
 
 function isBrsError(error: Error | BrsError): error is BrsError {
     let maybeBrsError = error as BrsError;

--- a/src/runner/JestRunner.ts
+++ b/src/runner/JestRunner.ts
@@ -1,5 +1,5 @@
 import { Config } from "@jest/types";
-import { ExecuteWithScope, types as BrsTypes } from "brs";
+import { ExecuteWithScope, types as BrsTypes } from "@rokucommunity/brs";
 import { JestReporter } from "../reporter/JestReporter";
 import { TestRunner } from "./TestRunner";
 

--- a/src/runner/TestRunner.ts
+++ b/src/runner/TestRunner.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { types as BrsTypes, ExecuteWithScope } from "brs";
+import { types as BrsTypes, ExecuteWithScope } from "@rokucommunity/brs";
 import { formatInterpreterError } from "../util";
 
 export class TestRunner {

--- a/test/reporter/jest-reporter.test.ts
+++ b/test/reporter/jest-reporter.test.ts
@@ -3,7 +3,7 @@ import { PassThrough } from "stream";
 import { JestReporter } from "../../src/reporter/JestReporter";
 import * as Reporters from "@jest/reporters";
 import * as TestResult from "@jest/test-result";
-import { BrsError } from "brs/types/Error";
+import { BrsError } from "@rokucommunity/brs/types/Error";
 
 jest.mock("@jest/reporters");
 let ReportersMock = Reporters as jest.Mocked<typeof Reporters>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,23 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@rokucommunity/brs@^0.45.0":
+  version "0.45.5"
+  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.45.5.tgz#4f0bb78aa7c9361913c097787bb143ea35df32db"
+  integrity sha512-xX+tWVclVPDkus33M4o807VVl6aX2C/nRBoQ9XmKWg6gxGUY9NQVceQIH1DGZpJEE2wSM57gUsaUXXMknY6Bmg==
+  dependencies:
+    commander "^2.12.2"
+    dayjs "^1.11.10"
+    decompress "^4.2.1"
+    fast-glob "^3.0.1"
+    long "^3.2.0"
+    memory-fs "^0.4.1"
+    nanomatch "^1.2.13"
+    p-settle "^2.1.0"
+    sanitize-filename "^1.6.3"
+    uuid "^8.3.0"
+    xmldoc "^1.1.2"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1144,23 +1161,6 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-brs@^0.43.0:
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/brs/-/brs-0.43.0.tgz#a56b95d845ff51473558bb723d2512a0cb9b5c46"
-  integrity sha512-1Wc6be3ZdqUAON2Y5gS6/n8knwj8xP9ZUJ4d2+t++WyDQCfqcjzRerWZgltS50YZWi35uDnnaYKtmoBFXyeihg==
-  dependencies:
-    commander "^2.12.2"
-    decompress "^4.2.1"
-    fast-glob "^3.0.1"
-    long "^3.2.0"
-    luxon "^1.8.3"
-    memory-fs "^0.4.1"
-    nanomatch "^1.2.13"
-    p-settle "^2.1.0"
-    sanitize-filename "^1.6.3"
-    uuid "^8.3.0"
-    xmldoc "^1.1.2"
-
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -1626,6 +1626,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+dayjs@^1.11.10:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
 debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -3926,11 +3931,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-luxon@^1.8.3:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
-  integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
 
 make-dir@^1.0.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,23 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@rokucommunity/brs@^0.45.0":
+  version "0.45.5"
+  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.45.5.tgz#4f0bb78aa7c9361913c097787bb143ea35df32db"
+  integrity sha512-xX+tWVclVPDkus33M4o807VVl6aX2C/nRBoQ9XmKWg6gxGUY9NQVceQIH1DGZpJEE2wSM57gUsaUXXMknY6Bmg==
+  dependencies:
+    commander "^2.12.2"
+    dayjs "^1.11.10"
+    decompress "^4.2.1"
+    fast-glob "^3.0.1"
+    long "^3.2.0"
+    memory-fs "^0.4.1"
+    nanomatch "^1.2.13"
+    p-settle "^2.1.0"
+    sanitize-filename "^1.6.3"
+    uuid "^8.3.0"
+    xmldoc "^1.1.2"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1144,23 +1161,6 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-brs@^0.45.0:
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/brs/-/brs-0.45.0.tgz#47ad9136a4693d356ecded337aa1d9fdad6a331e"
-  integrity sha512-997wtx16vorMRNfOm6FM+hU+nLoBRdMcX1B2n/TSYcYwMprpCpRU/pSt+OSjb+1pULMcuJTobqF6Rk1XLB3Bhg==
-  dependencies:
-    commander "^2.12.2"
-    decompress "^4.2.1"
-    fast-glob "^3.0.1"
-    long "^3.2.0"
-    luxon "^1.8.3"
-    memory-fs "^0.4.1"
-    nanomatch "^1.2.13"
-    p-settle "^2.1.0"
-    sanitize-filename "^1.6.3"
-    uuid "^8.3.0"
-    xmldoc "^1.1.2"
-
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -1626,6 +1626,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+dayjs@^1.11.10:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
 debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -3926,11 +3931,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-luxon@^1.8.3:
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.1.tgz#528cdf3624a54506d710290a2341aa8e6e6c61b0"
-  integrity sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==
 
 make-dir@^1.0.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,23 +598,6 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@rokucommunity/brs@^0.45.0":
-  version "0.45.5"
-  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.45.5.tgz#4f0bb78aa7c9361913c097787bb143ea35df32db"
-  integrity sha512-xX+tWVclVPDkus33M4o807VVl6aX2C/nRBoQ9XmKWg6gxGUY9NQVceQIH1DGZpJEE2wSM57gUsaUXXMknY6Bmg==
-  dependencies:
-    commander "^2.12.2"
-    dayjs "^1.11.10"
-    decompress "^4.2.1"
-    fast-glob "^3.0.1"
-    long "^3.2.0"
-    memory-fs "^0.4.1"
-    nanomatch "^1.2.13"
-    p-settle "^2.1.0"
-    sanitize-filename "^1.6.3"
-    uuid "^8.3.0"
-    xmldoc "^1.1.2"
-
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1161,6 +1144,23 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
+brs@^0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/brs/-/brs-0.45.0.tgz#47ad9136a4693d356ecded337aa1d9fdad6a331e"
+  integrity sha512-997wtx16vorMRNfOm6FM+hU+nLoBRdMcX1B2n/TSYcYwMprpCpRU/pSt+OSjb+1pULMcuJTobqF6Rk1XLB3Bhg==
+  dependencies:
+    commander "^2.12.2"
+    decompress "^4.2.1"
+    fast-glob "^3.0.1"
+    long "^3.2.0"
+    luxon "^1.8.3"
+    memory-fs "^0.4.1"
+    nanomatch "^1.2.13"
+    p-settle "^2.1.0"
+    sanitize-filename "^1.6.3"
+    uuid "^8.3.0"
+    xmldoc "^1.1.2"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -1626,11 +1626,6 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
-
-dayjs@^1.11.10:
-  version "1.11.13"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
-  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
 debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -3931,6 +3926,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^1.8.3:
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.1.tgz#528cdf3624a54506d710290a2341aa8e6e6c61b0"
+  integrity sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==
 
 make-dir@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
# Changes
Update to use rokucommunity/brs 0.47.0
Update brs references to rokucommunity/brs
Update roca version to 0.26.0

# JIRA
[[HULUROKU-6968]](https://jira.disneystreaming.com/browse/HULUROKU-6968)

# Testing 
- yarn install
- yarn run-s clean build test

# Next Steps:
Once this change is stable and merged, we'll need to update the package.json in cube-roku for @hulu/roca: "^0.26.0" and @rokucommunity/brs: "^0.47.0"

# Blockers:
- Unit tests are failing, but inconsistently (this is even reproducible on main sometimes) 
- many dependencies are in need of upgrades, see [dependabot PRs](https://github.com/hulu/roca/pulls/app%2Fdependabot)
- I've tried testing individual dependabot PRs and some pass and some fail (again, this is not consistently reproducible)
- I started to go down a larger `yarn upgrade` rabbit-hole so it may be preferred to do piece-meal upgrades since this project is very stale.
