### PR TITLE
[HULUROKU-7877] Replace brs package with @rokucommunity/brs version 0.45.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
+    "@rokucommunity/brs": "^0.45.2",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.21",
     "@types/long": "^4.0.1",
     "@types/memory-fs": "^0.3.2",
     "@types/xmldoc": "^1.1.5",
-    "brs": "^0.43.0",
     "docsify-cli": "^4.4.2",
     "doctoc": "^1.4.0",
     "husky": "^4.2.5",
@@ -72,9 +72,7 @@
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.9.7"
   },
-  "peerDependencies": {
-    "brs": "^0.43.0"
-  },
+  "peerDependencies": {},
   "lint-staged": {
     "./README.md": "doctoc",
     "*.{ts,js}": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
-    "@rokucommunity/brs": "^0.45.2",
+    "@rokucommunity/brs": "0.47.2",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.21",
     "@types/long": "^4.0.1",
@@ -73,7 +73,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "@rokucommunity/brs": "^0.45.2"
+    "@rokucommunity/brs": "^0.47.2"
   },
   "lint-staged": {
     "./README.md": "doctoc",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.9.7"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "@rokucommunity/brs": "^0.45.2"
+  },
   "lint-staged": {
     "./README.md": "doctoc",
     "*.{ts,js}": [

--- a/resources/tap/tap.brs
+++ b/resources/tap/tap.brs
@@ -32,21 +32,23 @@ end sub
 ' Prints a TAP testing plan in the form of "1..${numberOfTests}"
 ' @param {integer} numberOfTests - the number of test cases being run
 sub __tap_plan(numberOfTests as integer)
-    print m.getIndent() "1.." numberOfTests
+    print m.getIndent() "1.." numberOfTests.toStr().trim()
 end sub
 
 ' Prints a "test case passed" message to the TAP stream
 ' @param {integer} index - the zero-based index of the test that passed
 ' @param {string} rawTitle - the unsanitized title of the test that passed
 sub __tap_pass(index as integer, rawTitle as string)
-    print m.getIndent() "ok " index + 1 " - " m.formatTitle(rawTitle)
+    index += 1
+    print m.getIndent() "ok " index.toStr().trim() " - " m.formatTitle(rawTitle)
 end sub
 
 ' Prints a "test case skipped" message to the TAP stream
 ' @param {integer} index - the zero-based index of the test that was skipped
 ' @param {string} rawTitle - the unsanitized title of the test that was skipped
 sub __tap_skip(index as integer, rawTitle as string)
-    print m.getIndent() "ok " index + 1 " - " m.formatTitle(rawTitle) " # skip"
+    index += 1
+    print m.getIndent() "ok " index.toStr().trim() " - " m.formatTitle(rawTitle) " # skip"
 end sub
 
 ' Prints a "test case failed" message to the TAP stream
@@ -54,7 +56,8 @@ end sub
 ' @param {string} rawTitle - the unsanitized title of the test that failed
 ' @param {assocarray} [metadata] - blob of data to be printed in an indented YAML block
 sub __tap_fail(index as integer, rawTitle as string, metadata = invalid as object)
-    print m.getIndent() "not ok " index + 1 " - " m.formatTitle(rawTitle)
+    index += 1
+    print m.getIndent() "not ok " index.toStr().trim() " - " m.formatTitle(rawTitle)
     if metadata <> invalid then
         m.printExtras(metadata)
     end if

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -1,7 +1,7 @@
 import { createContext } from "istanbul-lib-report";
 import { create as createReport, ReportOptions } from "istanbul-reports";
 import { createCoverageMap } from "istanbul-lib-coverage";
-import { getCoverageResults } from "brs";
+import { getCoverageResults } from "@rokucommunity/brs";
 
 /*
  * Generates coverage reports using the given list of reporters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import { types, ExecuteWithScope, createExecuteWithScope } from "brs";
+import {
+    types,
+    ExecuteWithScope,
+    createExecuteWithScope,
+} from "@rokucommunity/brs";
 import fastGlob from "fast-glob";
 import * as path from "path";
 import * as c from "ansi-colors";

--- a/src/reporter/JestReporter.ts
+++ b/src/reporter/JestReporter.ts
@@ -21,7 +21,7 @@ import {
     createFailureMessage,
 } from "./utils";
 import type { Config } from "@jest/types";
-import { BrsError } from "brs/types/Error";
+import { BrsError } from "@rokucommunity/brs/types/Error";
 
 function isBrsError(error: Error | BrsError): error is BrsError {
     let maybeBrsError = error as BrsError;

--- a/src/runner/JestRunner.ts
+++ b/src/runner/JestRunner.ts
@@ -1,5 +1,5 @@
 import { Config } from "@jest/types";
-import { ExecuteWithScope, types as BrsTypes } from "brs";
+import { ExecuteWithScope, types as BrsTypes } from "@rokucommunity/brs";
 import { JestReporter } from "../reporter/JestReporter";
 import { TestRunner } from "./TestRunner";
 

--- a/src/runner/TestRunner.ts
+++ b/src/runner/TestRunner.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { types as BrsTypes, ExecuteWithScope } from "brs";
+import { types as BrsTypes, ExecuteWithScope } from "@rokucommunity/brs";
 import { formatInterpreterError } from "../util";
 
 export class TestRunner {

--- a/test/reporter/jest-reporter.test.ts
+++ b/test/reporter/jest-reporter.test.ts
@@ -3,7 +3,7 @@ import { PassThrough } from "stream";
 import { JestReporter } from "../../src/reporter/JestReporter";
 import * as Reporters from "@jest/reporters";
 import * as TestResult from "@jest/test-result";
-import { BrsError } from "brs/types/Error";
+import { BrsError } from "@rokucommunity/brs/types/Error";
 
 jest.mock("@jest/reporters");
 let ReportersMock = Reporters as jest.Mocked<typeof Reporters>;

--- a/test/runner/file-match.test.ts
+++ b/test/runner/file-match.test.ts
@@ -19,22 +19,26 @@ describe("globMatchFiles", () => {
 
     it("Finds all .test.brs files when not given patterns", async () => {
         let results = await wrappedGlobMatchFiles([]);
-        expect(results).toEqual([
-            "fly-you-fools.test.brs",
-            "bar/bar-suffix.test.brs",
-            "bar/bar.test.brs",
-            "bar/prefix-bar.test.brs",
-            "foo/main.test.brs",
-            "foo2/main.test.brs",
-        ]);
+        expect(results).toEqual(
+            expect.arrayContaining([
+                "fly-you-fools.test.brs",
+                "bar/bar-suffix.test.brs",
+                "bar/bar.test.brs",
+                "bar/prefix-bar.test.brs",
+                "foo/main.test.brs",
+                "foo2/main.test.brs",
+            ])
+        );
     });
 
     it("Partially matches on filename suffix when given a .brs extension", async () => {
         let results = await wrappedGlobMatchFiles(["bar.test.brs"]);
-        expect(results).toEqual([
-            "bar/bar.test.brs",
-            "bar/prefix-bar.test.brs",
-        ]);
+        expect(results).toEqual(
+            expect.arrayContaining([
+                "bar/bar.test.brs",
+                "bar/prefix-bar.test.brs",
+            ])
+        );
     });
 
     it("Can handle a full path to a file", async () => {
@@ -44,20 +48,24 @@ describe("globMatchFiles", () => {
 
     it("Can handle asterisks in pattern", async () => {
         let results = await wrappedGlobMatchFiles(["bar*.test.brs"]);
-        expect(results).toEqual([
-            "bar/bar-suffix.test.brs",
-            "bar/bar.test.brs",
-            "bar/prefix-bar.test.brs",
-        ]);
+        expect(results).toEqual(
+            expect.arrayContaining([
+                "bar/bar-suffix.test.brs",
+                "bar/bar.test.brs",
+                "bar/prefix-bar.test.brs",
+            ])
+        );
     });
 
     it("Looks for both partial directory and file matches when not given a .brs extension", async () => {
         let results = await wrappedGlobMatchFiles(["foo"]);
-        expect(results).toEqual([
-            "fly-you-fools.test.brs",
-            "foo/main.test.brs",
-            "foo2/main.test.brs",
-        ]);
+        expect(results).toEqual(
+            expect.arrayContaining([
+                "fly-you-fools.test.brs",
+                "foo/main.test.brs",
+                "foo2/main.test.brs",
+            ])
+        );
     });
 
     it("Excludes files when handling directories", async () => {
@@ -72,10 +80,12 @@ describe("globMatchFiles", () => {
 
     it("Handles multiple patterns", async () => {
         let results = await wrappedGlobMatchFiles(["main", "prefix"]);
-        expect(results).toEqual([
-            "bar/prefix-bar.test.brs",
-            "foo/main.test.brs",
-            "foo2/main.test.brs",
-        ]);
+        expect(results).toEqual(
+            expect.arrayContaining([
+                "bar/prefix-bar.test.brs",
+                "foo/main.test.brs",
+                "foo2/main.test.brs",
+            ])
+        );
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,23 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@rokucommunity/brs@^0.45.2":
+  version "0.45.2"
+  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.45.2.tgz#6331739ded314dd5d44b06b8b4572e415bb0e53d"
+  integrity sha512-PaIy+xlppFMBqepShV1hdbveUKLbVv7oQlKezVPOh8zB4tUfi/VhcQQDDD+b7Q0mpChNDzunjkiWmWNUa59fVg==
+  dependencies:
+    commander "^2.12.2"
+    decompress "^4.2.1"
+    fast-glob "^3.0.1"
+    long "^3.2.0"
+    luxon "^1.8.3"
+    memory-fs "^0.4.1"
+    nanomatch "^1.2.13"
+    p-settle "^2.1.0"
+    sanitize-filename "^1.6.3"
+    uuid "^8.3.0"
+    xmldoc "^1.1.2"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1139,27 +1156,17 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
-
-brs@^0.43.0:
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/brs/-/brs-0.43.0.tgz#a56b95d845ff51473558bb723d2512a0cb9b5c46"
-  integrity sha512-1Wc6be3ZdqUAON2Y5gS6/n8knwj8xP9ZUJ4d2+t++WyDQCfqcjzRerWZgltS50YZWi35uDnnaYKtmoBFXyeihg==
-  dependencies:
-    commander "^2.12.2"
-    decompress "^4.2.1"
-    fast-glob "^3.0.1"
-    long "^3.2.0"
-    luxon "^1.8.3"
-    memory-fs "^0.4.1"
-    nanomatch "^1.2.13"
-    p-settle "^2.1.0"
-    sanitize-filename "^1.6.3"
-    uuid "^8.3.0"
-    xmldoc "^1.1.2"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -1191,12 +1198,12 @@ buffer-alloc@^1.2.0:
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-fill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
-  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
+  integrity sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==
 
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
@@ -1702,7 +1709,7 @@ decompress-targz@^4.0.0:
 decompress-unzip@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
-  integrity sha1-3qrM39FK6vhVePczroIQ+bSEj2k=
+  integrity sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==
   dependencies:
     file-type "^3.8.0"
     get-stream "^2.2.0"
@@ -2207,7 +2214,18 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.0.1, fast-glob@^3.2.5:
+fast-glob@^3.0.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
+fast-glob@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
@@ -2253,7 +2271,7 @@ fb-watchman@^2.0.0:
 fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
 
@@ -2272,12 +2290,12 @@ figures@^3.2.0:
 file-type@^3.8.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
-  integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
+  integrity sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==
 
 file-type@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
-  integrity sha1-LdvqfHP/42No365J3DOMBYwritY=
+  integrity sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==
 
 file-type@^6.1.0:
   version "6.2.0"
@@ -2298,6 +2316,13 @@ fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -2443,7 +2468,7 @@ get-port@^5.0.0:
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
-  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
+  integrity sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
@@ -2474,7 +2499,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.1.0, glob-parent@~5.1.0:
+glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2522,7 +2547,12 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.10:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -2916,7 +2946,7 @@ is-installed-globally@^0.3.1:
 is-natural-number@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
-  integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
+  integrity sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==
 
 is-negative-zero@^2.0.0:
   version "2.0.1"
@@ -3901,7 +3931,7 @@ log-update@^4.0.0:
 long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
-  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
+  integrity sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==
 
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
@@ -3928,9 +3958,9 @@ lru-cache@^6.0.0:
     yallist "^4.0.0"
 
 luxon@^1.8.3:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
-  integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.1.tgz#528cdf3624a54506d710290a2341aa8e6e6c61b0"
+  integrity sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -3988,7 +4018,7 @@ medium-zoom@^1.0.6:
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
-  integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
+  integrity sha512-cda4JKCxReDXFXRqOHPQscuIYg1PvxbE2S2GP45rnwfEK+vZaXC8C1OFvdHIbgw0DLzowXGVoxLaAmlgRy14GQ==
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
@@ -4034,6 +4064,14 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -4249,7 +4287,7 @@ oauth-sign@~0.9.0:
 object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -4411,7 +4449,7 @@ p-map@^4.0.0:
 p-reflect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reflect/-/p-reflect-1.0.0.tgz#f4fa1ee1bb546d8eb3ec0321148dfe0a79137bb8"
-  integrity sha1-9Poe4btUbY6z7AMhFI3+CnkTe7g=
+  integrity sha512-rlngKS+EX3nvI7xIzA0xKNVEAguWdIqAZVbn02z1m73ehXBdX66aTdD0bCvIu0cDwbU3TK9w3RYrppKpO3EnKQ==
 
 p-settle@^2.1.0:
   version "2.1.0"
@@ -4431,7 +4469,7 @@ p-timeout@^3.1.0:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+  integrity sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -4550,7 +4588,7 @@ path-type@^4.0.0:
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -4562,6 +4600,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 pidtree@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
@@ -4570,7 +4613,7 @@ pidtree@^0.3.0:
 pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+  integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 pify@^3.0.0:
   version "3.0.0"
@@ -4580,14 +4623,14 @@ pify@^3.0.0:
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
+  integrity sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==
   dependencies:
     pinkie "^2.0.0"
 
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+  integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -4671,7 +4714,7 @@ prompts@^2.0.1:
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
-  integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+  integrity sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==
 
 psl@^1.1.28:
   version "1.8.0"
@@ -4761,7 +4804,20 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.3.0, readable-stream@^2.3.5:
+readable-stream@^2.0.1, readable-stream@^2.3.0, readable-stream@^2.3.5:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.0.2:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5002,10 +5058,15 @@ rxjs@^6.5.5:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -5041,10 +5102,10 @@ sanitize-filename@^1.6.3:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-sax@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+sax@^1.2.4:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
 saxes@^5.0.0:
   version "5.0.1"
@@ -5726,7 +5787,7 @@ trough@^1.0.0:
 truncate-utf8-bytes@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
-  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  integrity sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==
   dependencies:
     utf8-byte-length "^1.0.1"
 
@@ -5994,9 +6055,9 @@ use@^3.1.0:
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
 utf8-byte-length@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
-  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz#f9f63910d15536ee2b2d5dd4665389715eac5c1e"
+  integrity sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -6229,11 +6290,11 @@ xmlchars@^2.2.0:
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xmldoc@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.1.2.tgz#6666e029fe25470d599cd30e23ff0d1ed50466d7"
-  integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.3.0.tgz#7823225b096c74036347c9ec5924d06b6a3cebab"
+  integrity sha512-y7IRWW6PvEnYQZNZFMRLNJw+p3pezM4nKYPfr15g4OOW9i8VpeydycFuipE2297OvZnh3jSb2pxOt9QpkZUVng==
   dependencies:
-    sax "^1.2.1"
+    sax "^1.2.4"
 
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.2"
@@ -6353,7 +6414,7 @@ yargs@^15.3.1, yargs@^15.4.1:
 yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,20 +598,23 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@rokucommunity/brs@^0.45.2":
-  version "0.45.2"
-  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.45.2.tgz#6331739ded314dd5d44b06b8b4572e415bb0e53d"
-  integrity sha512-PaIy+xlppFMBqepShV1hdbveUKLbVv7oQlKezVPOh8zB4tUfi/VhcQQDDD+b7Q0mpChNDzunjkiWmWNUa59fVg==
+"@rokucommunity/brs@0.47.2":
+  version "0.47.2"
+  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.47.2.tgz#7a232e7b7f93abc7ac5edf8086ab049ee4d1cbc8"
+  integrity sha512-IUvxWhWQ6Q1VyadxDHZxGsgMjRREePXShPLmJy0GUZReI6EAl7EH1lNcILjsMkb4YUXydOXeVFYaZhDMqG4Cbw==
   dependencies:
-    commander "^2.12.2"
+    chalk "^4.1.2"
+    commander "^2.20.3"
+    crc "^3.8.0"
+    dayjs "^1.11.10"
     decompress "^4.2.1"
     fast-glob "^3.0.1"
     long "^3.2.0"
-    luxon "^1.8.3"
     memory-fs "^0.4.1"
     nanomatch "^1.2.13"
     p-settle "^2.1.0"
     sanitize-filename "^1.6.3"
+    strip-ansi "^6.0.1"
     uuid "^8.3.0"
     xmldoc "^1.1.2"
 
@@ -879,6 +882,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1210,7 +1218,7 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer@^5.2.1:
+buffer@^5.1.0, buffer@^5.2.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -1318,6 +1326,14 @@ chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -1486,7 +1502,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@^2.12.2, commander@^2.8.1:
+commander@^2.12.1, commander@^2.20.3, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1576,6 +1592,13 @@ cp-file@^7.0.0:
     nested-error-stacks "^2.0.0"
     p-event "^4.1.0"
 
+crc@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6"
+  integrity sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==
+  dependencies:
+    buffer "^5.1.0"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1633,6 +1656,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+dayjs@^1.11.10:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
 debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -3957,11 +3985,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-luxon@^1.8.3:
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.1.tgz#528cdf3624a54506d710290a2341aa8e6e6c61b0"
-  integrity sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==
-
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -5524,6 +5547,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Jira: [HULUROKU-7877](https://jira.disneystreaming.com/browse/HULUROKU-7877)
- Replace the "brs" package with "@rokucommunity/brs" in package.json
- Use @rokucommunity/brs version 0.45.2 (later versions introduce issues with roca's unit tests)
- Update roca typescript files to use the new namespace "@rokucommunity/brs"