### PR TITLE
[HULUROKU-7919] Suppress color output from the BRS interpreter

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yargs": "^13.2.4"
   },
   "devDependencies": {
-    "@rokucommunity/brs": "0.47.2",
+    "@rokucommunity/brs": "0.47.4",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.21",
     "@types/long": "^4.0.1",
@@ -73,7 +73,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "@rokucommunity/brs": "^0.47.2"
+    "@rokucommunity/brs": "^0.47.4"
   },
   "lint-staged": {
     "./README.md": "doctoc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ async function run(brsSourceFiles: string[], options: CliOptions) {
             stderr: process.stderr,
             generateCoverage: coverageEnabled,
             componentDirs: ["test", "tests"],
+            noColor: true,
         });
     } catch (e) {
         console.error(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,8 @@
         /* Experimental Options */
         // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
         // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-        "plugins": []
+        "plugins": [],
+        "skipLibCheck": true
     },
     "include": ["./src/"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,10 +598,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@rokucommunity/brs@0.47.2":
-  version "0.47.2"
-  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.47.2.tgz#7a232e7b7f93abc7ac5edf8086ab049ee4d1cbc8"
-  integrity sha512-IUvxWhWQ6Q1VyadxDHZxGsgMjRREePXShPLmJy0GUZReI6EAl7EH1lNcILjsMkb4YUXydOXeVFYaZhDMqG4Cbw==
+"@rokucommunity/brs@0.47.4":
+  version "0.47.4"
+  resolved "https://registry.yarnpkg.com/@rokucommunity/brs/-/brs-0.47.4.tgz#8542e39e475d4464b0e6510665a7f81071bb5f72"
+  integrity sha512-N/6NmToi3UKJHFC5UUwt1EjQlP8q9ihNFMbDjtqzy8VKc88F5raU7QhqXxCzwp9RJV8JDDQATNRDuLTqoLLbuw==
   dependencies:
     chalk "^4.1.2"
     commander "^2.20.3"


### PR DESCRIPTION
Jira: [HULUROKU-7919](https://jira.disney.com/browse/HULUROKU-7919)

- Update to `@rokucommunity/brs` version 0.47.4
- Invoke the brs interpreter with a `noColor` flag to preserve the TAP interface (see [Test Anything Protocol](https://testanything.org/) )