### PR TITLE
changes to support correct boolean values for deepEquals

### DIFF
--- a/resources/assert_lib.brs
+++ b/resources/assert_lib.brs
@@ -186,11 +186,7 @@ function __roca_deepEquals(lhs as object, rhs as object) as boolean
         end for
     end if
 
-    if __roca_isNumeric(lhs) and __roca_isNumeric(rhs) then
-        if lhs <> rhs then return false
-    end if
-
-    if __roca_isString(lhs) and __roca_isString(rhs) then
+    if _roca_isSameValueType(lhs, rhs) then
         if lhs <> rhs then return false
     end if
 
@@ -265,12 +261,20 @@ function __roca_isInvalid(value as dynamic) as boolean
     return type(value) = "roInvalid"
 end function
 
+function __roca_isBoolean(value as dynamic) as boolean
+    return value <> invalid and type(value) = "roBoolean"
+end function
+
 function __roca_isFunction(value as dynamic) as boolean
     return value <> invalid and getInterface(value, "ifFunction") <> invalid
 end function
 
 function __roca_isNumeric(value as dynamic) as boolean
     return  __roca_isInteger(value) or __roca_isFloat(value) or __roca_isDouble(value)
+end function
+
+function _roca_isSameValueType(lhs as dynamic, rhs as dynamic) as boolean
+    return (__roca_isNumeric(lhs) and __roca_isNumeric(rhs)) or (__roca_isString(lhs) and __roca_isString(rhs)) or (__roca_isBoolean(lhs) and __roca_isBoolean(rhs))
 end function
 
 function __roca_isRoSGNode(obj as dynamic) as boolean

--- a/test/e2e/assert/assert.test.js
+++ b/test/e2e/assert/assert.test.js
@@ -3,7 +3,6 @@ const { rocaInDir } = require("../util");
 describe("assert", () => {
     test("mock-function-calls", async () => {
         let results = await rocaInDir(__dirname, "mock-function-calls");
-
         expect(results.passes).toMatchObject([
             { fullTitle: "hasBeenCalled success" },
             { fullTitle: "hasBeenCalledTimes success 0" },
@@ -16,6 +15,10 @@ describe("assert", () => {
             { fullTitle: "hasBeenCalledWith success multiple calls" },
             { fullTitle: "hasBeenCalledWith success boolean true value" },
             { fullTitle: "hasBeenCalledWith success boolean false value" },
+            { fullTitle: "deepEquals success array" },
+            { fullTitle: "deepEquals success boolean values" },
+            { fullTitle: "deepEquals success string values" },
+            { fullTitle: "deepEquals success numeric values" },
         ]);
 
         expect(results.failures).toMatchObject([
@@ -130,6 +133,46 @@ describe("assert", () => {
                     message:
                         "Expected mock function 'fakeFunc' to have been called with args (true)",
                     name: "m.assert.hasBeenCalledWith",
+                },
+            },
+            {
+                fullTitle: "deepEquals failure array",
+                err: {
+                    actual: "[2]",
+                    expected: "[1]",
+                    message:
+                        "Expected mock function 'fakeFunc' should have returned [2], but [1] is expected",
+                    name: "m.deepEquals",
+                },
+            },
+            {
+                fullTitle: "deepEquals failure boolean values",
+                err: {
+                    actual: "true",
+                    expected: "false",
+                    message:
+                        "Expected mock function 'fakeFunc' should have returned true, but false is expected",
+                    name: "m.deepEquals",
+                },
+            },
+            {
+                fullTitle: "deepEquals failure string values",
+                err: {
+                    actual: "test",
+                    expected: "false",
+                    message:
+                        "Expected mock function 'fakeFunc' should have returned 'test', but false is expected",
+                    name: "m.deepEquals",
+                },
+            },
+            {
+                fullTitle: "deepEquals failure numeric values",
+                err: {
+                    actual: "22",
+                    expected: "11",
+                    message:
+                        "Expected mock function 'fakeFunc' should have returned 22, but 11 is expected",
+                    name: "m.deepEquals",
                 },
             },
         ]);

--- a/test/e2e/assert/mock-function-calls/tests/deepEquals.test.brs
+++ b/test/e2e/assert/mock-function-calls/tests/deepEquals.test.brs
@@ -1,0 +1,55 @@
+function main(args as object) as object
+    return roca(args).describe("deepEquals", sub()
+        m.it("success array", sub()
+            argument = [2]
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, argument, "arguments should match")
+        end sub)
+
+        m.it("success boolean values", sub()
+            argument = true
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, argument, "arguments should match")
+        end sub)
+
+        m.it("success string values", sub()
+            argument = "test"
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, argument, "arguments should match")
+        end sub)
+
+        m.it("success numeric values", sub()
+            argument = 22
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, argument, "arguments should match")
+        end sub)  
+
+        m.it("failure array", sub()
+            argument = [2]
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, [1], "Expected mock function 'fakeFunc' should have returned [2], but [1] is expected")
+        end sub)
+
+        m.it("failure boolean values", sub()
+            argument = true
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, false, "Expected mock function 'fakeFunc' should have returned true, but false is expected")        
+        end sub)
+
+        m.it("failure string values", sub()
+            argument = "test"
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, false, "Expected mock function 'fakeFunc' should have returned 'test', but false is expected")
+        end sub)
+        
+        m.it("failure numeric values", sub()
+            argument = 22
+            result = fakeFunc(argument)
+            m.assert.deepEquals(result, 11, "Expected mock function 'fakeFunc' should have returned 22, but 11 is expected")
+        end sub)  
+    end sub)
+end function
+
+function fakeFunc(arg as dynamic)
+    return arg
+end function


### PR DESCRIPTION
Added changes to compare all types in scope of `deepEquals` function, added more tests for checking new logic as well
<img width="408" height="289" alt="Screenshot 2026-04-03 at 12 59 29" src="https://github.com/user-attachments/assets/1da1ecad-8857-4af3-b2d0-6ed8c678b5ec" />
